### PR TITLE
Modified DefaultHandler arg handling

### DIFF
--- a/lib/DefaultHandler.js
+++ b/lib/DefaultHandler.js
@@ -5,14 +5,17 @@ function DefaultHandler(callback, options){
 	this._done = false;
 	this._inSpecialTag = false;
 	this._tagStack = [];
-	if(options) this._options = options; //otherwise, the prototype is used
-	if(callback) this._callback = callback;
-}
 
-//default options
-DefaultHandler.prototype._options = {
-	ignoreWhitespace: false //Keep whitespace-only text nodes
-};
+    if(typeof callback === "object"){
+        this._options = callback;
+        this._callback = false;
+    }else{
+        // default options
+        // keep whitespace-only text nodes
+        this._options = options || { ignoreWhitespace: false };
+        this._callback = callback || false;
+    }
+}
 
 //Resets the handler back to starting state
 DefaultHandler.prototype.onreset = DefaultHandler;


### PR DESCRIPTION
Now, if you want to get a dom with options but
without a callback, you can do:

``` javascript
var opts = { .....options..... };
var handler = new htmlparser.DefaultHandler(opts);
```

instead of:

``` javascript
var handler = new htmlparser.DefaultHandler(function(){}, opts);
```

which might lead to uncaught errors.
