### PR TITLE
Cleaned up DomUtils

### DIFF
--- a/lib/DomUtils.js
+++ b/lib/DomUtils.js
@@ -1,139 +1,163 @@
-var ElementType = require("./ElementType.js");
+var ElementType = require("./ElementType.js"),
+    arrayPush = Array.prototype.push,
+    DomUtils = module.exports;
 
-function getTest (checkVal) {
-	return function (value) { return value === checkVal; };
-}
-
-var arrayPush = Array.prototype.push;
 function filterArray(test, arr, recurse, limit){
-	var result = [], childs;
-	
-	for(var i = 0, j = arr.length; i < j; i++){
-		if(test(arr[i])){
-			result.push(arr[i]);
-			if(--limit <= 0) break;
-		}
-		
-		if(recurse && (childs = arr[i].children)){
-			childs = filterArray(test, childs, recurse, limit);
-			arrayPush.apply(result, childs);
-			limit -= childs.length;
-			if(limit <= 0) break;
-		}
-	}
-	return result;
+    var result = [], childs;
+
+    for(var i = 0, j = arr.length; i < j; i++){
+        if(test(arr[i])){
+            result.push(arr[i]);
+            if(--limit <= 0) break;
+        }
+
+        childs = arr[i].children;
+        if(recurse && childs){
+            childs = filterArray(test, childs, recurse, limit);
+            arrayPush.apply(result, childs);
+            limit -= childs.length;
+            if(limit <= 0) break;
+        }
+    }
+
+    return result;
 }
 
 function filter(test, element, recurse, limit){
-	if(recurse !== false) recurse = true;
-	if(isNaN(limit)) limit = 1/0;
-	if(!Array.isArray(element)){
-		element = [element];
-	}
-	return filterArray(test, element, recurse, limit);
+    if(recurse !== false) recurse = true;
+    if(isNaN(limit)) limit = Infinity;
+    if(!Array.isArray(element)) element = [element];
+
+    return filterArray(test, element, recurse, limit);
 }
 
-module.exports = {
-	testElement: function testElement(options, element) {
-		 var type = element.type;
-	
-		for(var key in options){
-			if(key === "tag_name"){
-				if(type !== ElementType.Tag && type !== ElementType.Script && type !== ElementType.Style) return false;
-				if(!options.tag_name(element.name)) return false;
-			} else if(key === "tag_type") {
-				if(!options.tag_type(type)) return false;
-			} else if(key === "tag_contains") {
-				if(type !== ElementType.Text && type !== ElementType.Comment && type !== ElementType.Directive) return false;
-				if(!options.tag_contains(element.data)) return false;
-			} else if(!element.attribs || !options[key](element.attribs[key]))
-				return false;
-		}
-	
-		 return true;
-	}, 
-	
-	getElements: function(options, element, recurse, limit){
-		for(var key in options){
-			if(typeof options[key] !== "function"){
-				options[key] = getTest(options[key]);
-			}
-		}
-		
-		return filter(this.testElement.bind(null, options), element, recurse, limit);
-	},
+DomUtils.testElement = function(options, element){
+    var type = element.type,
+        keys = Object.keys(options),
+        len = keys.length;
 
-	getElementById: function(id, element, recurse) {
-		var result;
-		if(typeof id === "function"){
-			result = filter(function(elem){
-				return elem.attribs && id(elem.attribs);
-			}, element, recurse, 1);
-		}
-		else{
-			result = filter(function(elem){
-				return elem.attribs && elem.attribs.id === id;
-			}, element, recurse, 1);
-		}
-		return result.length ? result[0] : null;
-	},
+    for(var i = 0; i < len; i++){
+        var key = keys[i];
 
-	getElementsByTagName: function(name, element, recurse, limit){
-		if(typeof name === "function") return filter(function(elem){
-			var type = elem.type;
-			if(type !== ElementType.Tag && type !== ElementType.Script && type !== ElementType.Style) return false;
-			return name(elem.name);
-		}, element, recurse, limit);
-		
-		return filter(function(elem){
-			var type = elem.type;
-			if(type !== ElementType.Tag && type !== ElementType.Script && type !== ElementType.Style) return false;
-			return elem.name === name;
-		}, element, recurse, limit);
-	},
+        switch(key){
+            case "tag_name":
+                if(type !== ElementType.Tag && type !== ElementType.Script && type !== ElementType.Style) return false;
+                if(!options.tag_name(element.name)) return false;
+                break;
+            case "tag_type":
+                if(!options.tag_type(type)) return false;
+                break;
+            case "tag_contains":
+                if(type !== ElementType.Text && type !== ElementType.Comment && type !== ElementType.Directive) return false;
+                if(!options.tag_contains(element.data)) return false;
+                break;
+            default:
+                if(!element.attribs || !options[key](element.attribs[key])) return false;
+                break;
+        }
+    }
 
-	getElementsByTagType: function(type, element, recurse, limit){
-		if(typeof type === "function"){
-			return filter(function(elem){return type(elem.type);}, element, recurse, limit);
-		}
-		else return filter(function(elem){return elem.type === type;}, element, recurse, limit);
-	},
-	
-	getInnerHTML: function(elem){
-		if(!elem.children) return "";
-		
-		var childs = elem.children,
-			childNum = childs.length,
-			ret = "";
-		
-		for(var i = 0; i < childNum; i++){
-			ret += this.getOuterHTML(childs[i]);
-		}
-		
-		return ret;
-	},
-	
-	getOuterHTML: function(elem){
-		var type = elem.type;
+    return true;
+}
 
-		if(type === ElementType.Text) return elem.data;
-		if(type === ElementType.Comment) return "<!--" + elem.data + "-->";
-		
-		var ret = "<" + elem.name;
-		
-		var value;
-		for(var name in elem.attribs){
-			value = elem.attribs[name];
-			ret += " " + name + "=";
-			
-			if(/^[^\s"\'\`\=\<\>]+$/.test(value)) ret += value;
-			else if(value.indeOf("\"") !== -1) ret += "'" + value + "'";
-			else ret += "\"" + value + "\"";
-		}
-		
-		if(type === ElementType.Directive) return ret + ">";
-		if(type === ElementType.Tag && !elem.children) return ret + " />";
-		
-		return ">" + ret + this.getInnerHTML(elem) + "</" + elem.name + ">";
-	}
-};
+DomUtils.getElements = function(options, element, recurse, limit){
+    var keys = Object.keys(options),
+        len = keys.length;
+
+    for(var i = 0; i < len; i++){
+        var key = keys[i];
+
+        if(typeof options[key] !== "function"){
+            var checker = options[key];
+            options[key] = function(val){ return val === checker };
+        }
+    }
+
+    return filter(this.testElement.bind(null, options), element, recurse, limit);
+}
+
+DomUtils.getElementById = function(id, element, recurse){
+    var result;
+
+    if(typeof id === "function"){
+        result = filter(function(elem){ return elem.attribs && id(elem.attribs) }, element, recurse, 1);
+    }else{
+        result = filter(function(elem){ return elem.attribs && elem.attribs.id === id }, element, recurse, 1);
+    }
+
+    return result.length ? result[0] : null;
+}
+
+DomUtils.getElementsByTagName = function(name, element, recurse, limit){
+    if(typeof name === "function") return filter(function(elem){
+        var type = elem.type;
+        if(type !== ElementType.Tag && type !== ElementType.Script && type !== ElementType.Style)
+            return false;
+        return name(elem.name);
+    }, element, recurse, limit);
+
+    return filter(function(elem){
+        var type = elem.type;
+        if(type !== ElementType.Tag && type !== ElementType.Script && type !== ElementType.Style)
+            return false;
+        return elem.name === name;
+    }, element, recurse, limit);
+}
+
+DomUtils.getElementsByTagType = function(type, element, recurse, limit){
+    if(typeof type === "function")
+        return filter(function(elem){ return type(elem.type) }, element, recurse, limit);
+    else
+        return filter(function(elem){ return elem.type === type }, element, recurse, limit);
+}
+
+DomUtils.getInnerHTML = function(elem){
+    if(!elem.children) return "";
+
+    var childs = elem.children,
+        childNum = childs.length,
+        ret = "";
+
+    for(var i = 0; i < childNum; i++){
+        ret += this.getOuterHTML(childs[i]);
+    }
+
+    return ret;
+}
+
+DomUtils.getOuterHTML = function(elem){
+    var type = elem.type,
+        name = elem.name;
+
+    if(type === ElementType.Text) return elem.data;
+    if(type === ElementType.Comment) return "<!--" + elem.data + "-->";
+
+    var attrStr = "";
+    if(elem.attribs){
+        var attrs = Object.keys(elem.attribs),
+            len = attrs.length;
+
+        for(var i = 0; i < len; i++){
+            var attr = attrs[i],
+                val = elem.attribs[attr];
+
+            attrStr += " " + attr + "=\"" + val + "\"";
+
+            /* Is this required? Method forgets quotes
+            if(/^[^\s"\'\`\=\<\>]+$/.test(val))
+                attrStr += val;
+            else if(val.indeOf("\"") !== -1)
+                attrStr += "'" + val + "'";
+            else
+                attrStr += "\"" + val + "\"";
+            */
+        }
+    }
+
+    var ret = "<" + name + attrStr + ">";
+
+    if(type === ElementType.Directive) return ret;
+
+    ret += this.getInnerHTML(elem) + "</" + name + ">"
+    return ret;
+}

--- a/tests/DomUtils/04-outer_html.js
+++ b/tests/DomUtils/04-outer_html.js
@@ -1,0 +1,10 @@
+var DomUtils = require("../../lib/DomUtils.js");
+
+exports.name = "Get outer HTML";
+exports.getElements = function(dom){
+    return '<tag1 id="asdf"> <script>text</script> <!-- comment --> <tag2> text </tag2></tag1>';
+};
+exports.getByFunction = function(dom){
+    return DomUtils.getOuterHTML(DomUtils.getElementById("asdf", dom, true));
+};
+exports.expected = '<tag1 id="asdf"> <script>text</script> <!-- comment --> <tag2> text </tag2></tag1>';

--- a/tests/DomUtils/05-inner_html.js
+++ b/tests/DomUtils/05-inner_html.js
@@ -1,0 +1,10 @@
+var DomUtils = require("../../lib/DomUtils.js");
+
+exports.name = "Get inner HTML";
+exports.getElements = function(dom){
+    return ' <script>text</script> <!-- comment --> <tag2> text </tag2>';
+};
+exports.getByFunction = function(dom){
+    return DomUtils.getInnerHTML(DomUtils.getElementById("asdf", dom, true));
+};
+exports.expected = ' <script>text</script> <!-- comment --> <tag2> text </tag2>';


### PR DESCRIPTION
- Attempted to perform some optimization
- Fixed some style inconsistencies
- Added tests for DomUtils HTML methods

This fixes a few issues related to `getInnerHTML` and `getOuterHTML` and generally cleans up the file. All tests pass.

In case you want to check out some of the HTML method inconsistencies in the current version, try:

``` javascript
var htmlparser2 = require("htmlparser2"),
    DomUtils = htmlparser2.DomUtils;

var handler = new htmlparser2.DomHandler(),
    parser = new htmlparser2.Parser(handler);

parser.parseComplete('<tag1 id="asdf"> <script>text</script> <!-- comment --> <tag2> text </tag2></tag1>');

console.log(DomUtils.getOuterHTML(handler.dom[0]));
console.log(DomUtils.getInnerHTML(handler.dom[0]));
```

which yields the (improper) HTML:

```
><tag1 id=asdf ><scripttext</script> <!-- comment --> ><tag2 text </tag2></tag1>
 ><scripttext</script> <!-- comment --> ><tag2 text </tag2>
```

With this pull, we get:

```
<tag1 id="asdf"> <script>text</script> <!-- comment --> <tag2> text </tag2></tag1>
 <script>text</script> <!-- comment --> <tag2> text </tag2>
```
