### PR TITLE
Lower case tags in getElementsByTagName()

### DIFF
--- a/lib/DomUtils.js
+++ b/lib/DomUtils.js
@@ -95,12 +95,13 @@ DomUtils.getElementsByTagName = function(name, element, recurse, limit){
             return false;
         return name(elem.name);
     }, element, recurse, limit);
-
+    
+    name = name.toLowerCase();
     return filter(function(elem){
         var type = elem.type;
         if(type !== ElementType.Tag && type !== ElementType.Script && type !== ElementType.Style)
             return false;
-        return elem.name === name;
+        return elem.name.toLowerCase() === name;
     }, element, recurse, limit);
 }
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en/DOM/document.getElementsByTagName - tags are lower cased before comparing. This fixes that bug.
