### PR TITLE
fix of htmlparser.DomUtils.getOuterHTML for directives

### DIFF
--- a/lib/DomUtils.js
+++ b/lib/DomUtils.js
@@ -126,6 +126,7 @@ DomUtils.getOuterHTML = function(elem){
 
 	if(type === ElementType.Text) return elem.data;
 	if(type === ElementType.Comment) return "<!--" + elem.data + "-->";
+	if(type === ElementType.Directive) return "<" + elem.data + ">";
 
 	var ret = "<" + name;
 	if(elem.hasOwnProperty("attribs")){


### PR DESCRIPTION
htmlparser.DomUtils.getOuterHTML doesn't work correctly for directives

``` js
var htmlparser = require('htmlparser2');
var handler = new htmlparser.DefaultHandler();
var parser = new htmlparser.Parser(handler);

var html = '<!doctype html>';
parser.parseComplete(html);

// must returns <!doctype html> but returns <!doctype> instead
console.log(htmlparser.DomUtils.getInnerHTML({ children: handler.dom }));
```
