### PR TITLE
Recognize closing CDATA tags as end of "special"

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -225,6 +225,7 @@ Parser.prototype._writeCDATA = function(data){
 		}
 		this._contentFlags ^= SpecialTags[ElementType.CDATA];
 		if(this._cbs.oncdataend) this._cbs.oncdataend();
+		this._wroteSpecial = false;
     }
     else if(this._cbs.ontext) this._cbs.ontext(data + this._tagSep);
 };

--- a/tests/Events/05-cdata-special.json
+++ b/tests/Events/05-cdata-special.json
@@ -1,0 +1,97 @@
+{
+  "name": "CDATA",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "<script>/*<![CDATA[*/ asdf ><asdf></adsf><> fo/*]]>*/</script>",
+  "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "script"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "script",
+        {}
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "/*"
+      ]
+    },
+    {
+      "event": "cdatastart",
+      "data": []
+    },
+    {
+      "event": "text",
+      "data": [
+        "*/ asdf >"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "<"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "asdf>"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "<"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "/adsf>"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "<"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        ">"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        " fo/*"
+      ]
+    },
+    {
+      "event": "cdataend",
+      "data": []
+    },
+    {
+      "event": "text",
+      "data": [
+        "*/"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "script"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This allows for correct parsing of text that directly follows CDATA tags.

This ought to resolve a problem we're having upstream: https://github.com/tbranyen/backbone.layoutmanager/issues/280
