### PR TITLE
Do not parse CDATA-like text inside special tags

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -221,6 +221,7 @@ Parser.prototype._parseTags = function(force){
 				}
 				this._processCloseTag(elementData);
 			}
+			else if(this._contentFlags !== 0) this._writeSpecial(rawData, lastTagSep);
 			else if(elementData.charAt(0) === "!"){
 				if(elementData.substr(1, 7) === "[CDATA["){
 					this._contentFlags |= SpecialTags[ElementType.CDATA];
@@ -241,7 +242,6 @@ Parser.prototype._parseTags = function(force){
 					);
 				}
 			}
-			else if(this._contentFlags !== 0) this._writeSpecial(rawData, lastTagSep);
 			else if(elementData.charAt(0) === "?"){
 				if(this._cbs.onprocessinginstruction){
 					this._cbs.onprocessinginstruction(

--- a/tests/Events/05-cdata-special.json
+++ b/tests/Events/05-cdata-special.json
@@ -1,5 +1,5 @@
 {
-  "name": "CDATA",
+  "name": "CDATA (inside special)",
   "options": {
     "handler": {},
     "parser": {}
@@ -26,43 +26,9 @@
       ]
     },
     {
-      "event": "cdatastart",
-      "data": []
-    },
-    {
       "event": "text",
       "data": [
-        "*/ asdf >"
-      ]
-    },
-    {
-      "event": "text",
-      "data": [
-        "<"
-      ]
-    },
-    {
-      "event": "text",
-      "data": [
-        "asdf>"
-      ]
-    },
-    {
-      "event": "text",
-      "data": [
-        "<"
-      ]
-    },
-    {
-      "event": "text",
-      "data": [
-        "/adsf>"
-      ]
-    },
-    {
-      "event": "text",
-      "data": [
-        "<"
+        "<![CDATA[*/ asdf "
       ]
     },
     {
@@ -74,17 +40,43 @@
     {
       "event": "text",
       "data": [
-        " fo/*"
+        "<asdf"
       ]
-    },
-    {
-      "event": "cdataend",
-      "data": []
     },
     {
       "event": "text",
       "data": [
-        "*/"
+        ">"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "</adsf"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        ">"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "<"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "> fo/*]]"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        ">*/"
       ]
     },
     {


### PR DESCRIPTION
Special nodes (e.g. script tags, style tags, comment nodes, etc.) can
contain only text nodes.
