### PR TITLE
Add a new test for issue #36

### DIFF
--- a/tests/Documents/Attributes.html
+++ b/tests/Documents/Attributes.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+	<title>Attributes test</title>
+</head>
+<body>
+	<!-- Normal attributes -->
+	<button id="test0" class="value0" title="value1">class="value0" title="value1"</button>
+
+	<!-- Attributes with no quotes or value -->
+	<button id="test1" class=value2 disabled>class=value2 disabled</button>
+
+	<!-- Attributes with no space between them. No valid, but accepted by the browser -->
+	<button id="test2" class="value4"title="value5">class="value4"title="value5"</button>
+</body>
+</html>

--- a/tests/Events/09-attributes.json
+++ b/tests/Events/09-attributes.json
@@ -1,0 +1,68 @@
+{
+  "name": "attributes (no white space, no value, no quotes)",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "<button class=\"test0\"title=\"test1\" disabled value=test2>adsf</button>",
+  "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "button"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "button",
+        {
+          "class": "test0",
+          "title": "test1",
+          "disabled": "",
+          "value": "test2"
+        }
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "class",
+        "test0"
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "title",
+        "test1"
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "disabled",
+        ""
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "value",
+        "test2"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "adsf"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "button"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Only finds first attribute when there is no whitespace between
attributes.
- Added a html example
- Added a test
