### PR TITLE
fix for script tags

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -150,9 +150,11 @@ Tokenizer.prototype.write = function(chunk){
 				this._emitToken("closetag");
 				this._state = TEXT;
 				this._sectionStart = this._index + 1;
+				this._special = 0;
 			} else if(whitespace(c)){
 				this._emitToken("closetag");
 				this._state = AFTER_CLOSING_TAG_NAME;
+				this._special = 0;
 			}
 		} else if(this._state === AFTER_CLOSING_TAG_NAME){
 			//skip everything until ">"

--- a/tests/Events/02-template.json
+++ b/tests/Events/02-template.json
@@ -4,8 +4,21 @@
     "handler": {},
     "parser": {}
   },
-  "html": "<script type=\"text/template\"><h1>Heading1</h1></script>",
+  "html": "<p><script type=\"text/template\"><h1>Heading1</h1></script></p>",
   "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "p"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "p",
+        {}
+      ]
+    },
     {
       "event": "opentagname",
       "data": [
@@ -38,6 +51,12 @@
       "event": "closetag",
       "data": [
         "script"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "p"
       ]
     }
   ]


### PR DESCRIPTION
I found some unexpected behavior:  

```
<script>...</script><p>Foo</p> 
```

will cause the tokenizer to properly emit a "closetag" event for </script> but, all that follows will only emit "ontext" events. 

I assume this behavior exists for style elements as well, but did not check for it.

My fix is to force this._special back to 0 after emitting a closetag event.

I updated the Event/02-template.json test by wrapping the html in a <p>...</p> element to test for this.  Prior to my fix, the </p> would have emitted an 'ontext' event and now it properly emits an 'onclosetag' event.
