### PR TITLE
Fix default behavior when parse attributes with the same name

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -164,7 +164,7 @@ Parser.prototype.onattribname = function(name){
 
 Parser.prototype.onattribvalue = function attribValue(value){
 	if(this._cbs.onattribute) this._cbs.onattribute(this._attribname, value);
-	if(this._attribs) this._attribs[this._attribname] = value;
+	if(this._attribs && !this._attribs[this._attribname]) this._attribs[this._attribname] = value;
 	this._attribname = "";
 };
 


### PR DESCRIPTION
When htmlparser2 parses incorrect html/xml with several attributes with the same name, it returns last attribute. But all major browsers returns the first attribute.
See example http://jsfiddle.net/r8B9m/

This fix changes default behavior of htmlparser to browser like.
