### PR TITLE
Added missing void elements.

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -68,7 +68,12 @@ var emptyTags = {
 	link: true,
 	meta: true,
 	param: true,
-	embed: true
+	embed: true,
+	command: true,
+	keygen: true,
+	source: true,
+	track: true,
+	wbr: true
 };
 
 function Parser(cbs, options){


### PR DESCRIPTION
When parsing the examples in http://picture.responsiveimages.org/ with jsdom I noticed that the sequences of `<source>` tags didn't end up as siblings in the parsed DOM -- instead the first tag became the parent of the second etc. Turns out `source` (and a couple of others) are missing in the `emptyTags` hash in `lib/Parser.js`.

Source: http://www.w3.org/TR/html5/syntax.html#void-elements
