### PR TITLE
[tokenizer] don't reset comment state in case of long endings

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -283,6 +283,8 @@ Tokenizer.prototype.write = function(chunk){
 				this._cbs.oncomment(this._buffer.substring(this._sectionStart, this._index - 2));
 				this._state = TEXT;
 				this._sectionStart = this._index + 1;
+			} else if (c === '-') {
+				// Keep the state at AFTER_COMMENT_2
 			} else {
 				this._state = IN_COMMENT;
 			}

--- a/tests/Events/12-long-comment-end.json
+++ b/tests/Events/12-long-comment-end.json
@@ -1,0 +1,20 @@
+{
+  "name": "Long comment ending",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "<meta id='before'><!-- text ---><meta id='after'>",
+  "expected": [
+  { "event": "opentagname", "data": [ "meta" ] },
+  { "event": "attribute",   "data": [ "id", "before" ] },
+  { "event": "opentag",     "data": [ "meta", {"id": "before"} ] },
+  { "event": "closetag",    "data": [ "meta" ] },
+  { "event": "comment",     "data": [ " text -" ] },
+  { "event": "commentend",  "data": [] },
+  { "event": "opentagname", "data": [ "meta" ] },
+  { "event": "attribute",   "data": [ "id", "after" ] },
+  { "event": "opentag",     "data": [ "meta", {"id": "after"} ] },
+  { "event": "closetag",    "data": [ "meta" ] }
+  ]
+}


### PR DESCRIPTION
Found the bug when scraping http://www.guardian.co.uk/world/2013/jun/06/florida-tropical-storm-andrea

See testcase below:

``` javascript
var Parser = require('htmlparser2').Parser;

var stream = new Parser({
  onopentag: function (tagname, attr) {
    console.log('open: ' + tagname, attr);
  },

  oncomment: function (value) {
    console.log('open comment: ' + value);
  },

  ontext: function (text) {
    console.log('text: ' + text);
  },

  oncommentend: function () {
    console.log('close comment');
  },

  onclosetag: function (tagname) {
    console.log('close: ' + tagname);
  }
});

stream.write('<meta id="before">');
stream.write('<!-- text --->');
stream.write('<meta id="after">');
stream.end();
```

Outputs this on master:

```
open: meta { id: 'before' }
close: meta
open comment:  text ---><meta id="after">
close comment
```

with this fix:

```
open: meta { id: 'before' }
close: meta
open comment:  text -
close comment
open: meta { id: 'after' }
close: meta
```
