### PR TITLE
[Tokenizer] don't reset CDATA state in case of long endings

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -326,7 +326,9 @@ Tokenizer.prototype.write = function(chunk){
 				this._cbs.oncdata(this._buffer.substring(this._sectionStart, this._index - 2));
 				this._state = TEXT;
 				this._sectionStart = this._index + 1;
-			} else {
+			} else if (c === ']') {
+				// Keep the state at AFTER_CDATA_2
+			}else {
 				this._state = IN_CDATA;
 			}
 		}

--- a/tests/Events/13-long-cdata-end.json
+++ b/tests/Events/13-long-cdata-end.json
@@ -1,0 +1,22 @@
+{
+  "name": "Long CDATA ending",
+  "options": {
+    "handler": {},
+    "parser": {"xmlMode": true}
+  },
+  "html": "<before /><tag><![CDATA[ text ]]]></tag><after />",
+  "expected": [
+  { "event": "opentagname", "data": [ "before" ] },
+  { "event": "opentag",     "data": [ "before", {} ] },
+  { "event": "closetag",    "data": [ "before" ] },
+  { "event": "opentagname", "data": [ "tag" ] },
+  { "event": "opentag",     "data": [ "tag", {} ] },
+  { "event": "cdatastart",  "data": [] },
+  { "event": "text",        "data": [ " text ]" ] },
+  { "event": "cdataend",    "data": [] },
+  { "event": "closetag",    "data": [ "tag" ] },
+  { "event": "opentagname", "data": [ "after" ] },
+  { "event": "opentag",     "data": [ "after", {} ] },
+  { "event": "closetag",    "data": [ "after" ] }
+  ]
+}


### PR DESCRIPTION
Fixes know issue regarding long CDATA endings, see #49
