### PR TITLE
Fix perf regression in the Tokenizer

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -90,7 +90,7 @@ Tokenizer.prototype.write = function(chunk){
 		var c = this._buffer.charAt(this._index);
 		if(this._state === TEXT){
 			if(c === "<"){
-				this._emitIfToken("text");
+				this._emitIfToken("ontext");
 				this._state = BEFORE_TAG_NAME;
 				this._sectionStart = this._index;
 			}
@@ -120,16 +120,16 @@ Tokenizer.prototype.write = function(chunk){
 			}
 		} else if(this._state === IN_TAG_NAME){
 			if(c === "/"){
-				this._emitToken("opentagname");
+				this._emitToken("onopentagname");
 				this._cbs.onselfclosingtag();
 				this._state = AFTER_CLOSING_TAG_NAME;
 			} else if(c === ">"){
-				this._emitToken("opentagname");
+				this._emitToken("onopentagname");
 				this._cbs.onopentagend();
 				this._state = TEXT;
 				this._sectionStart = this._index + 1;
 			} else if(whitespace(c)){
-				this._emitToken("opentagname");
+				this._emitToken("onopentagname");
 				this._state = BEFORE_ATTRIBUTE_NAME;
 			}
 		} else if(this._state === BEFORE_CLOSING_TAG_NAME){
@@ -149,12 +149,12 @@ Tokenizer.prototype.write = function(chunk){
 			}
 		} else if(this._state === IN_CLOSING_TAG_NAME){
 			if(c === ">"){
-				this._emitToken("closetag");
+				this._emitToken("onclosetag");
 				this._state = TEXT;
 				this._sectionStart = this._index + 1;
 				this._special = 0;
 			} else if(whitespace(c)){
-				this._emitToken("closetag");
+				this._emitToken("onclosetag");
 				this._state = AFTER_CLOSING_TAG_NAME;
 				this._special = 0;
 			}
@@ -183,13 +183,13 @@ Tokenizer.prototype.write = function(chunk){
 			}
 		} else if(this._state === IN_ATTRIBUTE_NAME){
 			if(c === "="){
-				this._emitIfToken("attribname");
+				this._emitIfToken("onattribname");
 				this._state = BEFORE_ATTRIBUTE_VALUE;
 			} else if(whitespace(c)){
-				this._emitIfToken("attribname");
+				this._emitIfToken("onattribname");
 				this._state = AFTER_ATTRIBUTE_NAME;
 			} else if(c === "/" || c === ">"){
-				this._emitIfToken("attribname");
+				this._emitIfToken("onattribname");
 				this._state = BEFORE_ATTRIBUTE_NAME;
 				this._index--;
 			}
@@ -216,22 +216,22 @@ Tokenizer.prototype.write = function(chunk){
 			}
 		} else if(this._state === IN_ATTRIBUTE_VALUE_DOUBLE_QUOTES){
 			if(c === "\""){
-				this._emitToken("attribvalue");
+				this._emitToken("onattribvalue");
 				this._state = BEFORE_ATTRIBUTE_NAME;
 			}
 		} else if(this._state === IN_ATTRIBUTE_VALUE_SINGLE_QUOTES){
 			if(c === "'"){
-				this._emitToken("attribvalue");
 				this._state = BEFORE_ATTRIBUTE_NAME;	
+				this._emitToken("onattribvalue");
 			}
 		} else if(this._state === IN_ATTRIBUTE_VALUE_NO_QUOTES){
 			if(c === ">"){
-				this._emitToken("attribvalue");
+				this._emitToken("onattribvalue");
 				this._state = TEXT;
 				this._cbs.onopentagend();
 				this._sectionStart = this._index + 1;
 			} else if(whitespace(c)){
-				this._emitToken("attribvalue");
+				this._emitToken("onattribvalue");
 				this._state = BEFORE_ATTRIBUTE_NAME;
 			}
 		}
@@ -245,7 +245,7 @@ Tokenizer.prototype.write = function(chunk){
 			else this._state = IN_DECLARATION;
 		} else if(this._state === IN_DECLARATION){
 			if(c === ">"){
-				this._emitToken("declaration");
+				this._emitToken("ondeclaration");
 				this._state = TEXT;
 				this._sectionStart = this._index + 1;
 			}
@@ -256,7 +256,7 @@ Tokenizer.prototype.write = function(chunk){
 		*/
 		else if(this._state === IN_PROCESSING_INSTRUCTION){
 			if(c === ">"){
-				this._emitToken("processinginstruction");
+				this._emitToken("onprocessinginstruction");
 				this._state = TEXT;
 				this._sectionStart = this._index + 1;
 			}
@@ -492,7 +492,7 @@ Tokenizer.prototype.write = function(chunk){
 		this._index = 0;
 	} else {
 		if(this._state === TEXT){
-			this._emitIfToken("text");
+			this._emitIfToken("ontext");
 			this._buffer = "";
 			this._index = 0;
 		} else if(this._sectionStart === this._index){
@@ -522,15 +522,15 @@ Tokenizer.prototype.end = function(chunk){
 	//if there is remaining data, emit it in a reasonable way
 	if(this._buffer === "" || this._sectionStart === -1 || this._sectionStart === this._index);
 	else if(this._state === IN_CDATA || this._state === AFTER_CDATA_1 || this._state === AFTER_CDATA_2){
-		this._emitIfToken("cdata");
+		this._emitIfToken("oncdata");
 	} else if(this._state === IN_COMMENT || this._state === AFTER_COMMENT_1 || this._state === AFTER_COMMENT_2){
-		this._emitIfToken("comment");
+		this._emitIfToken("oncomment");
 	} else if(this._state === IN_TAG_NAME){
-		this._emitIfToken("opentagname");
+		this._emitIfToken("onopentagname");
 	} else if(this._state === IN_CLOSING_TAG_NAME){
-		this._emitIfToken("closetag");
+		this._emitIfToken("onclosetag");
 	} else {
-		this._emitIfToken("text");
+		this._emitIfToken("ontext");
 	}
 
 	this._cbs.onend();
@@ -541,13 +541,13 @@ Tokenizer.prototype.reset = function(){
 };
 
 Tokenizer.prototype._emitToken = function(name){
-	this._cbs["on" + name](this._buffer.substring(this._sectionStart, this._index));
+	this._cbs[name](this._buffer.substring(this._sectionStart, this._index));
 	this._sectionStart = -1;
 };
 
 Tokenizer.prototype._emitIfToken = function(name){
 	if(this._index > this._sectionStart){
-		this._cbs["on" + name](this._buffer.substring(this._sectionStart, this._index));
+		this._cbs[name](this._buffer.substring(this._sectionStart, this._index));
 	}
 	this._sectionStart = -1;
 };


### PR DESCRIPTION
After profiling the module, I see that a lot of time was lost in `_emitToken` and `_emitIfToken` method.
This is due to a useless concatenation that cost a lot since those methods are in the hot path.

My measure on my machine: 

Version 2.3.1 :
-> % node bench2.js
htmlparser2:  01.86 ms/el

Version 3.1.2 without the fix :
-> % node tests/bench.js 
htmlparser2:  04.50 ms/el

Version 3.1.2 with the fix :
-> % node tests/bench.js
htmlparser2:  01.75 ms/el
