### PR TITLE
Add parseDOM and parseFeed helper methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,18 @@ function defineProp(name, value){
 }
 
 module.exports = {
+	parseDOM: function (html) {
+		var handler = new module.exports.DomHandler();
+		var parser = new module.exports.Parser(handler);
+		parser.parseComplete(html);
+		return handler.dom;
+	},
+	parseFeed: function (feed) {
+		var handler = new module.exports.FeedHandler();
+		var parser = new module.exports.Parser(handler);
+		parser.parseComplete(feed);
+		return handler.dom;
+	},
 	get Parser(){
 		return defineProp("Parser", require("./Parser.js"));
 	},


### PR DESCRIPTION
I find myself using essentially this code 95% of the time when I'm using this library.  I think it would be helpful just to include these helpers by default.
