### PR TITLE
[tokenizer] fix case where `<` followed by whitespace doesn't parse

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -97,7 +97,7 @@ Tokenizer.prototype.write = function(chunk){
 		} else if(this._state === BEFORE_TAG_NAME){
 			if(c === "/"){
 				this._state = BEFORE_CLOSING_TAG_NAME;
-			} else if(c === ">" || this._special > 0) {
+			} else if(c === ">" || this._special > 0 || whitespace(c)) {
 				this._state = TEXT;
 			} else {
 				if(whitespace(c));

--- a/tests/Events/15-lt-whitespace.json
+++ b/tests/Events/15-lt-whitespace.json
@@ -1,0 +1,16 @@
+{
+  "name": "lt followed by whitespace",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "a < b",
+  "expected": [
+    {
+      "event": "text",
+      "data": [
+        "a < b"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
if you parse the string `'a < b'` everything after the `<` is lost (result: `'a '`).  Whereas other parsers, (chrome and firefox) the result is `'a &lt; b'`

Causing this bug on jsdom: tmpvar/jsdom#652
