### PR TITLE
Add startIndex and endIndex positional attributes to the parser

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -2,7 +2,7 @@ var Tokenizer = require("./Tokenizer.js");
 
 /*
 	Options:
-	
+
 	xmlMode: Special behavior for script/style tags (true by default)
 	lowerCaseAttributeNames: call .toLowerCase for each attribute name (true if xmlMode is `false`)
 	lowerCaseTags: call .toLowerCase for each tag name (true if xmlMode is `false`)
@@ -10,7 +10,7 @@ var Tokenizer = require("./Tokenizer.js");
 
 /*
 	Callbacks:
-	
+
 	oncdataend,
 	oncdatastart,
 	onclosetag,
@@ -81,6 +81,8 @@ function Parser(cbs, options){
 	this._attribs = null;
 	this._stack = [];
 	this._done = false;
+  this.startIndex = 0;
+  this.endIndex = undefined;
 
 	this._tokenizer = new Tokenizer(options, this);
 }
@@ -89,6 +91,9 @@ require("util").inherits(Parser, require("events").EventEmitter);
 
 //Tokenizer event handlers
 Parser.prototype.ontext = function(data){
+  this.startIndex = (this.endIndex === undefined) ? Math.max(this._tokenizer._sectionStart - 1, 0) : this.endIndex + 1;
+  this.endIndex = this._tokenizer._index - 1;
+
 	if(this._cbs.ontext) this._cbs.ontext(data);
 };
 
@@ -116,7 +121,10 @@ Parser.prototype.onopentagname = function(name){
 };
 
 Parser.prototype.onopentagend = function(){
-	if(this._attribname !== "") this.onattribvalue("");
+  this.startIndex = (this.endIndex === undefined) ? Math.max(this._tokenizer._sectionStart - 1, 0) : this.endIndex + 1;
+  this.endIndex = this._tokenizer._index;
+
+  if(this._attribname !== "") this.onattribvalue("");
 	if(this._attribs){
 		if(this._cbs.onopentag) this._cbs.onopentag(this._tagname, this._attribs);
 		this._attribs = null;
@@ -128,6 +136,9 @@ Parser.prototype.onopentagend = function(){
 };
 
 Parser.prototype.onclosetag = function(name){
+  this.startIndex = (this.endIndex === undefined) ? Math.max(this._tokenizer._sectionStart - 1, 0) : this.endIndex + 1;
+  this.endIndex = this._tokenizer._index;
+
 	if(!(this._options.xmlMode || "lowerCaseTags" in this._options) || this._options.lowerCaseTags){
 		name = name.toLowerCase();
 	}
@@ -145,7 +156,7 @@ Parser.prototype.onclosetag = function(name){
 		}
 	} else if(!this._options.xmlMode && (name === "br" || name === "p")){
 		this.onopentagname(name);
-		this.onselfclosingtag();		
+		this.onselfclosingtag();
 	}
 };
 
@@ -204,12 +215,18 @@ Parser.prototype.onprocessinginstruction = function(value){
 };
 
 Parser.prototype.oncomment = function(value){
-	if(this._cbs.oncomment) this._cbs.oncomment(value);
+  this.startIndex = (this.endIndex === undefined) ? Math.max(this._tokenizer._sectionStart - 4, 0) : this.endIndex + 1;
+  this.endIndex = this._tokenizer._index;
+
+  if(this._cbs.oncomment) this._cbs.oncomment(value);
 	if(this._cbs.oncommentend) this._cbs.oncommentend();
 };
 
 Parser.prototype.oncdata = function(value){
-	if(this._options.xmlMode){
+  this.startIndex = (this.endIndex === undefined) ? Math.max(this._tokenizer._sectionStart - 1, 0) : this.endIndex + 1;
+  this.endIndex = this._tokenizer._index;
+
+  if(this._options.xmlMode){
 		if(this._cbs.oncdatastart) this._cbs.oncdatastart();
 		if(this._cbs.ontext) this._cbs.ontext(value);
 		if(this._cbs.oncdataend) this._cbs.oncdataend();

--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -5,6 +5,7 @@ var i = 0,
     TEXT = i++,
     BEFORE_TAG_NAME = i++, //after <
     IN_TAG_NAME = i++,
+    BEFORE_SELF_CLOSING_TAG_NAME = i++,
     BEFORE_CLOSING_TAG_NAME = i++,
     IN_CLOSING_TAG_NAME = i++,
     AFTER_CLOSING_TAG_NAME = i++,
@@ -231,16 +232,19 @@ Tokenizer.prototype._stateBeforeAttributeName = function (c) {
 	if(whitespace(c)){
 		/* noop */
 	} else if(c === ">"){
+    if (this._state === BEFORE_SELF_CLOSING_TAG_NAME) {
+      this._cbs.onselfclosingtag();
+    } else {
+		  this._cbs.onopentagend();
+    }
 		this._state = TEXT;
-		this._cbs.onopentagend();
 		this._sectionStart = this._index + 1;
 
 		if(this._baseState !== IN_SCRIPT && this._baseState !== IN_STYLE){
 			this._baseState = TEXT;
 		}
 	} else if(c === "/"){
-		this._cbs.onselfclosingtag();
-		this._state = AFTER_CLOSING_TAG_NAME;
+		this._state = BEFORE_SELF_CLOSING_TAG_NAME;
 	} else {
 		this._state = IN_ATTRIBUTE_NAME;
 		this._sectionStart = this._index;
@@ -601,6 +605,8 @@ Tokenizer.prototype.write = function(chunk){
 			this._stateInCloseingTagName(c);
 		} else if(this._state === AFTER_CLOSING_TAG_NAME){
 			this._stateAfterCloseingTagName(c);
+		} else if(this._state === BEFORE_SELF_CLOSING_TAG_NAME){
+			this._stateBeforeAttributeName(c);
 		}
 
 		/*


### PR DESCRIPTION
Add start and end positional attributes to the parser (see #53).

I can't figure out how to easily add some tests to the existing ones.
