### PR TITLE
Fix existing and add new options

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -76,8 +76,7 @@ var voidElements = {
 var re_nameEnd = /\s|\//;
 
 function Parser(cbs, options){
-	options = options || {};
-	this._options = options;
+	this._options = options || {};
 	this._cbs = cbs || {};
 
 	this._tagname = "";
@@ -93,7 +92,7 @@ function Parser(cbs, options){
 	this._lowerCaseTagNames = "lowerCaseTags" in this._options ? !!this._options.lowerCaseTags : !this._options.xmlMode;
 	this._lowerCaseAttributeNames = "lowerCaseAttributeNames" in this._options ? !!this._options.lowerCaseAttributeNames : !this._options.xmlMode;
 
-	this._tokenizer = new Tokenizer(options, this);
+	this._tokenizer = new Tokenizer(this._options, this);
 }
 
 require("util").inherits(Parser, require("events").EventEmitter);


### PR DESCRIPTION
To allow a hybrid approach to parsing HTML code that may have certain XML constructs, a few more options have been added:
- **recognizeSelfClosing**: If set to `true` then self-closing tags will result in the tag being closed even if `xmlMode` is not set to `true`
- **recognizeCDATA**: If set to `true` then CDATA text will result in the `context` event being fired even if `xmlMode` is not set to `true`

Also, the `lowerCaseTags` and `lowerCaseAttributeNames` options have been fixed so that case conversion can be disabled in non-XML mode.
