### PR TITLE
Add self-closeing svg tags

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -70,7 +70,15 @@ var voidElements = {
 	param: true,
 	source: true,
 	track: true,
-	wbr: true
+	wbr: true,
+
+        //common self closing svg elements
+        path: true,
+        circle: true,
+        ellipse: true,
+        line: true,
+        rect: true,
+        use: true
 };
 
 var re_nameEnd = /\s|\//;
@@ -135,16 +143,16 @@ Parser.prototype.onopentagname = function(name){
 
 Parser.prototype.onopentagend = function(){
 	this._updatePosition(1);
-    
+
 	if(this._attribs){
 		if(this._cbs.onopentag) this._cbs.onopentag(this._tagname, this._attribs);
 		this._attribs = null;
 	}
-    
+
 	if(!this._options.xmlMode && this._cbs.onclosetag && this._tagname in voidElements){
 		this._cbs.onclosetag(this._tagname);
 	}
-    
+
 	this._tagname = "";
 };
 


### PR DESCRIPTION
Allows basic embedded svgs to be parsed correctly.
