### PR TITLE
Add index information to open/close tag callbacks

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -134,7 +134,9 @@ Parser.prototype.onopentagname = function(name){
 		name = name.toLowerCase();
 	}
 
+	this._updatePosition(1);
 	this._tagname = name;
+	this._tagStart = this._tokenizer._sectionStart;
 
 	if (!this._options.xmlMode && name in openImpliesClose) {
 		for(
@@ -156,12 +158,12 @@ Parser.prototype.onopentagend = function(){
 	this._updatePosition(1);
 
 	if(this._attribs){
-		if(this._cbs.onopentag) this._cbs.onopentag(this._tagname, this._attribs);
+		if(this._cbs.onopentag) this._cbs.onopentag(this._tagname, this._attribs, this._tagStart);
 		this._attribs = null;
 	}
 
 	if(!this._options.xmlMode && this._cbs.onclosetag && this._tagname in voidElements){
-		this._cbs.onclosetag(this._tagname);
+		this._cbs.onclosetag(this._tagname, this.endIndex);
 	}
 
 	this._tagname = "";
@@ -179,7 +181,7 @@ Parser.prototype.onclosetag = function(name){
 		if(pos !== -1){
 			if(this._cbs.onclosetag){
 				pos = this._stack.length - pos;
-				while(pos--) this._cbs.onclosetag(this._stack.pop());
+				while(pos--) this._cbs.onclosetag(this._stack.pop(), this.endIndex);
 			}
 			else this._stack.length = pos;
 		} else if(name === "p" && !this._options.xmlMode){


### PR DESCRIPTION
Allows parser callbacks to track the current position relative to the buffer.
