### PR TITLE
Update to latest version of domutils

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "domhandler": "2.2",
-    "domutils": "1.4",
+    "domutils": "1.5",
     "domelementtype": "1",
     "readable-stream": "1.1",
     "entities": "1.0"


### PR DESCRIPTION
I need the new `uniqueSort` utility method to implement a few features in Cheerio. 1.5 also has a bug fix for CDATA, which couldn't hurt.
