### PR TITLE
Handle partial comment endings as normal content

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -360,7 +360,13 @@ Tokenizer.prototype._stateInComment = function(c){
 	if(c === "-") this._state = AFTER_COMMENT_1;
 };
 
-Tokenizer.prototype._stateAfterComment1 = characterState("-", AFTER_COMMENT_2);
+Tokenizer.prototype._stateAfterComment1 = function(c){
+	if(c === "-"){
+		this._state = AFTER_COMMENT_2;
+	} else {
+		this._state = IN_COMMENT;
+	}
+};
 
 Tokenizer.prototype._stateAfterComment2 = function(c){
 	if(c === ">"){

--- a/test/Events/31-comment_false-ending.json
+++ b/test/Events/31-comment_false-ending.json
@@ -1,0 +1,9 @@
+{
+  "name": "Comment false ending",
+  "options": {},
+  "html": "<!-- a-b-> -->",
+  "expected": [
+    { "event": "comment",     "data": [ " a-b-> " ] },
+    { "event": "commentend",  "data": [] }
+  ]
+}


### PR DESCRIPTION
If a comment ending is interrupted by an unexpected character, treat the
parsed characters as comment content and revert to the "in comment"
state.
