### PR TITLE
Ignore readable-stream dependency in browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "jscs": "1.5.8",
     "jshint": "2"
   },
+  "browser": {
+    "readable-stream": false
+  },
   "license": "MIT",
   "jshintConfig": {
     "eqeqeq": true,


### PR DESCRIPTION
The `readable-stream` module adds 50kb of weight to Browserify builds unnecessarily. Browserify will automatically use node core `stream` anyway.  This adds a rule to `package.json` to ignore `readable-stream` in browserify builds.
