### PR TITLE
Add missing void elements

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -84,7 +84,10 @@ var voidElements = {
 	ellipse: true,
 	line: true,
 	rect: true,
-	use: true
+	use: true,
+	stop: true,
+	polyline: true,
+	polygone: true
 };
 
 var re_nameEnd = /\s|\//;


### PR DESCRIPTION
This adds a few more missing SVG void elements. Currently simple SVGs like the one at the top [here](http://www.w3schools.com/html/html5_svg.asp) are not parsed correctly.

Maybe it would be better to separate void elements and foreign elements to be able to parse everything correctly, but it seems like a lot of work... ;)
