### PR TITLE
add support for onparserinit event callback

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -113,6 +113,8 @@ function Parser(cbs, options){
 									!this._options.xmlMode;
 
 	this._tokenizer = new Tokenizer(this._options, this);
+
+	if(this._cbs.onparserinit) this._cbs.onparserinit(this);
 }
 
 require("util").inherits(Parser, require("events").EventEmitter);


### PR DESCRIPTION
So that the handler can obtain a reference to the `Parser` (and then access `Parser.startIndex` in its other callbacks).
Refs https://github.com/fb55/domhandler/issues/7
I am happy to add a unit test if necessary, just need a little guidance on how to go about that.
(Refs https://github.com/twbs/bootlint/issues/29)
