### PR TITLE
use entry:content if entry:summary is not exist

### DIFF
--- a/lib/FeedHandler.js
+++ b/lib/FeedHandler.js
@@ -57,7 +57,7 @@ FeedHandler.prototype.onend = function(){
 				addConditionally(entry, "id", "id", item);
 				addConditionally(entry, "title", "title", item);
 				if((tmp = getOneElement("link", item)) && (tmp = tmp.attribs) && (tmp = tmp.href)) entry.link = tmp;
-				addConditionally(entry, "description", "summary", item);
+				if((tmp = fetch("summary", item) || fetch("content", item))) entry.description = tmp;
 				if((tmp = fetch("updated", item))) entry.pubDate = new Date(tmp);
 				return entry;
 			});

--- a/test/Documents/Atom_Example.xml
+++ b/test/Documents/Atom_Example.xml
@@ -19,7 +19,7 @@
 		<link rel="edit" href="http://example.org/2003/12/13/atom03/edit"/>
 		<id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
 		<updated>2003-12-13T18:30:02Z</updated>
-		<summary>Some text.</summary>
+		<content type="html"><p>Some content.</p></content>
 	</entry>
 
 </feed>

--- a/test/Feeds/02-atom.js
+++ b/test/Feeds/02-atom.js
@@ -12,7 +12,7 @@ exports.expected = {
 		id: "urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a",
 		title: "Atom-Powered Robots Run Amok",
 		link: "http://example.org/2003/12/13/atom03",
-		description: "Some text.",
+		description: "Some content.",
 		pubDate: new Date("2003-12-13T18:30:02Z")
 	}]
 };

--- a/test/Stream/03-Atom.json
+++ b/test/Stream/03-Atom.json
@@ -592,28 +592,56 @@
       ]
     },
     {
-      "event": "opentagname",
+    "event": "opentagname",
       "data": [
-        "summary"
+        "content"
+      ]
+    },
+    {
+      "event": "attribute",
+      "data": [
+        "type",
+        "html"
       ]
     },
     {
       "event": "opentag",
       "data": [
-        "summary",
+        "content",
+        {
+          "type": "html"
+        }
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": [
+        "p"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "p",
         {}
       ]
     },
     {
       "event": "text",
       "data": [
-        "Some text."
+        "Some content."
       ]
     },
     {
       "event": "closetag",
       "data": [
-        "summary"
+        "p"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "content"
       ]
     },
     {
@@ -638,6 +666,12 @@
       "event": "closetag",
       "data": [
         "feed"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "\n"
       ]
     }
   ]


### PR DESCRIPTION
According to [RFC4287](http://tools.ietf.org/html/rfc4287#section-4.1.1.1), most atom:entry element may not contain a summary field, e.g: https://github.com/blog.atom.
So use entry:content if entry:summary is not exist please.
