### PR TITLE
opening tag fix based on html syntax standard

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -147,7 +147,7 @@ function Tokenizer(options, cbs){
 }
 
 Tokenizer.prototype._stateText = function(c){
-	if(c === "<"){
+	if(c === "<" && cNext.match(/[0-9a-z]/i)){
 		if(this._index > this._sectionStart){
 			this._cbs.ontext(this._getSection());
 		}
@@ -635,8 +635,9 @@ Tokenizer.prototype.write = function(chunk){
 Tokenizer.prototype._parse = function(){
 	while(this._index < this._buffer.length && this._running){
 		var c = this._buffer.charAt(this._index);
+		var cNext = this._buffer.charAt(this._index+1);
 		if(this._state === TEXT) {
-			this._stateText(c);
+			this._stateText(c, cNext);
 		} else if(this._state === BEFORE_TAG_NAME){
 			this._stateBeforeTagName(c);
 		} else if(this._state === IN_TAG_NAME) {


### PR DESCRIPTION
please see: 
http://www.w3.org/TR/html-markup/syntax.html#syntax-elements 

Start tags consist of the following parts, in exactly the following order:
A "<" character.
The element’s tag name.
Optionally, one or more attributes, each of which must be preceded by one or more space characters.
Optionally, one or more space characters.
Optionally, a "/" character, which may be present only if the element is a void element.
A ">" character.

and also tag name standarts:

http://www.w3.org/TR/html-markup/syntax.html#tag-name