### PR TITLE
Allow attribute values to be null, when no value is defined.

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -115,7 +115,7 @@ function Parser(cbs, options){
 									!!this._options.allowEmptyAttributeValues :
 									false;
 
-	if (this._allowEmptyAttributeValues) this._attribValue = null;
+	if(this._allowEmptyAttributeValues) this._attribValue = null;
 
 	this._tokenizer = new Tokenizer(this._options, this);
 
@@ -238,7 +238,7 @@ Parser.prototype.onattribname = function(name){
 };
 
 Parser.prototype.onattribdata = function(value){
-	if (this._allowEmptyAttributeValues && this._attribValue === null) this._attribValue = "";
+	if(this._allowEmptyAttributeValues && this._attribValue === null) this._attribValue = "";
 	this._attribvalue += value;
 };
 

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -111,6 +111,11 @@ function Parser(cbs, options){
 	this._lowerCaseAttributeNames = "lowerCaseAttributeNames" in this._options ?
 									!!this._options.lowerCaseAttributeNames :
 									!this._options.xmlMode;
+	this._allowEmptyAttributeValues = "allowEmptyAttributeValues" in this._options ?
+									!!this._options.allowEmptyAttributeValues :
+									false;
+
+	if (this._allowEmptyAttributeValues) this._attribValue = null;
 
 	this._tokenizer = new Tokenizer(this._options, this);
 
@@ -233,6 +238,7 @@ Parser.prototype.onattribname = function(name){
 };
 
 Parser.prototype.onattribdata = function(value){
+	if (this._allowEmptyAttributeValues && this._attribValue === null) this._attribValue = "";
 	this._attribvalue += value;
 };
 
@@ -245,7 +251,7 @@ Parser.prototype.onattribend = function(){
 		this._attribs[this._attribname] = this._attribvalue;
 	}
 	this._attribname = "";
-	this._attribvalue = "";
+	this._attribvalue = this._allowEmptyAttributeValues?null:"";
 };
 
 Parser.prototype._getInstructionName = function(value){


### PR DESCRIPTION
I have a case where I need to distinguish between having attribute values and not having attribute values.

e.g.

Now the code sets both attributes' value to an empty string.

I've added an option, that when set to true the value is set to true for cases like attrib1.