### PR TITLE
Remove duplicate key entry in .jscsrc

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -13,7 +13,6 @@
 
     "disallowEmptyBlocks": true,
 
-    "disallowSpaceAfterPrefixUnaryOperators": ["!"],
     "disallowSpaceBeforeBinaryOperators": [","],
     "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
     "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],


### PR DESCRIPTION
This key is overwritten two lines later (with a stricter setting).