### PR TITLE
Support for suspending parsing in <code> tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -101,6 +101,7 @@ function Parser(cbs, options){
 	this._attribvalue = "";
 	this._attribs = null;
 	this._stack = [];
+  this._codeBuffer = "";
 
 	this.startIndex = 0;
 	this.endIndex = null;
@@ -135,6 +136,10 @@ Parser.prototype._updatePosition = function(initialOffset){
 
 //Tokenizer event handlers
 Parser.prototype.ontext = function(data){
+  if (this._inCodeBlock === true) {
+    return;
+  }
+
 	this._updatePosition(1);
 	this.endIndex--;
 
@@ -148,6 +153,8 @@ Parser.prototype.onopentagname = function(name){
 
 	this._tagname = name;
 
+  if (this._inCodeBlock === true) return;
+
 	if(!this._options.xmlMode && name in openImpliesClose) {
 		for(
 			var el;
@@ -160,12 +167,27 @@ Parser.prototype.onopentagname = function(name){
 		this._stack.push(name);
 	}
 
-	if(this._cbs.onopentagname) this._cbs.onopentagname(name);
+	if(this._cbs.onopentagname) {
+    if (this._options.doNotParseCodeBlocks === true && this._tagname === 'code') {
+      this._inCodeBlock = true;
+      this._tokenizer.emitRawChars(true);
+    }
+    this._cbs.onopentagname(name);
+  }
 	if(this._cbs.onopentag) this._attribs = {};
+};
+
+Parser.prototype.onrawchar = function(char) {
+  if (this._inCodeBlock === true) {
+    if (this._codeBuffer.length === 0 && char === '>') return;
+    this._codeBuffer += char;
+  }
 };
 
 Parser.prototype.onopentagend = function(){
 	this._updatePosition(1);
+
+  if (this._inCodeBlock === true) return;
 
 	if(this._attribs){
 		if(this._cbs.onopentag) this._cbs.onopentag(this._tagname, this._attribs);
@@ -176,25 +198,42 @@ Parser.prototype.onopentagend = function(){
 		this._cbs.onclosetag(this._tagname);
 	}
 
+  if (this._options.doNotParseCodeBlocks === true && this._tagname === 'code') {
+    this._inCodeBlock = true;
+    this._tokenizer.emitRawChars(true);
+  }
+
 	this._tagname = "";
 };
 
 Parser.prototype.onclosetag = function(name){
 	this._updatePosition(1);
 
-	if(this._lowerCaseTagNames){
+  if(this._lowerCaseTagNames){
 		name = name.toLowerCase();
 	}
 
+  if (name === 'code' && this._options.doNotParseCodeBlocks === true) {
+    this._inCodeBlock = false;
+    this._tokenizer.emitRawChars(false);
+
+    // Emit the buffered code output slicing off the </code> from the end.
+    this._cbs.ontext(this._codeBuffer.slice(0, -7));
+    this._codeBuffer = "";
+  }
+
+  if (this._inCodeBlock === true) return;
+
 	if(this._stack.length && (!(name in voidElements) || this._options.xmlMode)){
 		var pos = this._stack.lastIndexOf(name);
-		if(pos !== -1){
-			if(this._cbs.onclosetag){
+		if (pos !== -1){
+			if (this._cbs.onclosetag){
 				pos = this._stack.length - pos;
 				while(pos--) this._cbs.onclosetag(this._stack.pop());
 			}
 			else this._stack.length = pos;
-		} else if(name === "p" && !this._options.xmlMode){
+		} else if(name === "p" && !this._options.xmlMode) {
+      if (this._inCodeBlock !== true)
 			this.onopentagname(name);
 			this._closeCurrentTag();
 		}
@@ -205,6 +244,10 @@ Parser.prototype.onclosetag = function(name){
 };
 
 Parser.prototype.onselfclosingtag = function(){
+  if (this._inCodeBlock === true) {
+    return;
+  }
+
 	if(this._options.xmlMode || this._options.recognizeSelfClosing){
 		this._closeCurrentTag();
 	} else {
@@ -221,13 +264,18 @@ Parser.prototype._closeCurrentTag = function(){
 	//(cheaper check than in onclosetag)
 	if(this._stack[this._stack.length - 1] === name){
 		if(this._cbs.onclosetag){
-			this._cbs.onclosetag(name);
+      if (this._inCodeBlock !== true)
+			  this._cbs.onclosetag(name);
 		}
 		this._stack.pop();
 	}
 };
 
 Parser.prototype.onattribname = function(name){
+  if (this._inCodeBlock === true) {
+    return;
+  }
+
 	if(this._lowerCaseAttributeNames){
 		name = name.toLowerCase();
 	}
@@ -235,10 +283,18 @@ Parser.prototype.onattribname = function(name){
 };
 
 Parser.prototype.onattribdata = function(value){
+  if (this._inCodeBlock === true) {
+    return;
+  }
+
 	this._attribvalue += value;
 };
 
 Parser.prototype.onattribend = function(){
+  if (this._inCodeBlock === true) {
+    return;
+  }
+
 	if(this._cbs.onattribute) this._cbs.onattribute(this._attribname, this._attribvalue);
 	if(
 		this._attribs &&

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -101,7 +101,7 @@ function Parser(cbs, options){
 	this._attribvalue = "";
 	this._attribs = null;
 	this._stack = [];
-  this._codeBuffer = "";
+	this._codeBuffer = "";
 
 	this.startIndex = 0;
 	this.endIndex = null;
@@ -136,9 +136,7 @@ Parser.prototype._updatePosition = function(initialOffset){
 
 //Tokenizer event handlers
 Parser.prototype.ontext = function(data){
-  if (this._inCodeBlock === true) {
-    return;
-  }
+	if(this._inCodeBlock === true) return;
 
 	this._updatePosition(1);
 	this.endIndex--;
@@ -147,13 +145,13 @@ Parser.prototype.ontext = function(data){
 };
 
 Parser.prototype.onopentagname = function(name){
-	if(this._lowerCaseTagNames){
+	if(this._lowerCaseTagNames) {
 		name = name.toLowerCase();
 	}
 
 	this._tagname = name;
 
-  if (this._inCodeBlock === true) return;
+	if(this._inCodeBlock === true) return;
 
 	if(!this._options.xmlMode && name in openImpliesClose) {
 		for(
@@ -168,26 +166,26 @@ Parser.prototype.onopentagname = function(name){
 	}
 
 	if(this._cbs.onopentagname) {
-    if (this._options.doNotParseCodeBlocks === true && this._tagname === 'code') {
-      this._inCodeBlock = true;
-      this._tokenizer.emitRawChars(true);
-    }
-    this._cbs.onopentagname(name);
-  }
+		if(this._options.doNotParseCodeBlocks === true && this._tagname === "code"){
+			this._inCodeBlock = true;
+			this._tokenizer.emitRawChars(true);
+		}
+		this._cbs.onopentagname(name);
+	}
 	if(this._cbs.onopentag) this._attribs = {};
 };
 
-Parser.prototype.onrawchar = function(char) {
-  if (this._inCodeBlock === true) {
-    if (this._codeBuffer.length === 0 && char === '>') return;
-    this._codeBuffer += char;
-  }
+Parser.prototype.onrawchar = function(char){
+	if(this._inCodeBlock === true){
+		if(this._codeBuffer.length === 0 && char === ">") return;
+		this._codeBuffer += char;
+	}
 };
 
 Parser.prototype.onopentagend = function(){
 	this._updatePosition(1);
 
-  if (this._inCodeBlock === true) return;
+	if(this._inCodeBlock === true) return;
 
 	if(this._attribs){
 		if(this._cbs.onopentag) this._cbs.onopentag(this._tagname, this._attribs);
@@ -198,10 +196,10 @@ Parser.prototype.onopentagend = function(){
 		this._cbs.onclosetag(this._tagname);
 	}
 
-  if (this._options.doNotParseCodeBlocks === true && this._tagname === 'code') {
-    this._inCodeBlock = true;
-    this._tokenizer.emitRawChars(true);
-  }
+	if(this._options.doNotParseCodeBlocks === true && this._tagname === "code") {
+		this._inCodeBlock = true;
+		this._tokenizer.emitRawChars(true);
+	}
 
 	this._tagname = "";
 };
@@ -209,31 +207,30 @@ Parser.prototype.onopentagend = function(){
 Parser.prototype.onclosetag = function(name){
 	this._updatePosition(1);
 
-  if(this._lowerCaseTagNames){
+	if(this._lowerCaseTagNames){
 		name = name.toLowerCase();
 	}
 
-  if (name === 'code' && this._options.doNotParseCodeBlocks === true) {
-    this._inCodeBlock = false;
-    this._tokenizer.emitRawChars(false);
+	if(name === "code" && this._options.doNotParseCodeBlocks === true) {
+		this._inCodeBlock = false;
+		this._tokenizer.emitRawChars(false);
 
-    // Emit the buffered code output slicing off the </code> from the end.
-    this._cbs.ontext(this._codeBuffer.slice(0, -7));
-    this._codeBuffer = "";
-  }
+		// Emit the buffered code output slicing off the </code> from the end.
+		this._cbs.ontext(this._codeBuffer.slice(0, -7));
+		this._codeBuffer = "";
+	}
 
-  if (this._inCodeBlock === true) return;
+	if(this._inCodeBlock === true) return;
 
 	if(this._stack.length && (!(name in voidElements) || this._options.xmlMode)){
 		var pos = this._stack.lastIndexOf(name);
-		if (pos !== -1){
-			if (this._cbs.onclosetag){
+		if(pos !== -1){
+			if(this._cbs.onclosetag){
 				pos = this._stack.length - pos;
 				while(pos--) this._cbs.onclosetag(this._stack.pop());
 			}
 			else this._stack.length = pos;
 		} else if(name === "p" && !this._options.xmlMode) {
-      if (this._inCodeBlock !== true)
 			this.onopentagname(name);
 			this._closeCurrentTag();
 		}
@@ -244,9 +241,7 @@ Parser.prototype.onclosetag = function(name){
 };
 
 Parser.prototype.onselfclosingtag = function(){
-  if (this._inCodeBlock === true) {
-    return;
-  }
+	if(this._inCodeBlock === true) return;
 
 	if(this._options.xmlMode || this._options.recognizeSelfClosing){
 		this._closeCurrentTag();
@@ -264,17 +259,15 @@ Parser.prototype._closeCurrentTag = function(){
 	//(cheaper check than in onclosetag)
 	if(this._stack[this._stack.length - 1] === name){
 		if(this._cbs.onclosetag){
-      if (this._inCodeBlock !== true)
-			  this._cbs.onclosetag(name);
+			if(this._inCodeBlock !== true)
+				this._cbs.onclosetag(name);
 		}
 		this._stack.pop();
 	}
 };
 
 Parser.prototype.onattribname = function(name){
-  if (this._inCodeBlock === true) {
-    return;
-  }
+	if(this._inCodeBlock === true) return;
 
 	if(this._lowerCaseAttributeNames){
 		name = name.toLowerCase();
@@ -283,17 +276,13 @@ Parser.prototype.onattribname = function(name){
 };
 
 Parser.prototype.onattribdata = function(value){
-  if (this._inCodeBlock === true) {
-    return;
-  }
+	if(this._inCodeBlock === true) return;
 
 	this._attribvalue += value;
 };
 
 Parser.prototype.onattribend = function(){
-  if (this._inCodeBlock === true) {
-    return;
-  }
+	if(this._inCodeBlock === true) return;
 
 	if(this._cbs.onattribute) this._cbs.onattribute(this._attribname, this._attribvalue);
 	if(
@@ -308,7 +297,7 @@ Parser.prototype.onattribend = function(){
 
 Parser.prototype._getInstructionName = function(value){
 	var idx = value.search(re_nameEnd),
-	    name = idx < 0 ? value : value.substr(0, idx);
+			name = idx < 0 ? value : value.substr(0, idx);
 
 	if(this._lowerCaseTagNames){
 		name = name.toLowerCase();

--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -144,6 +144,11 @@ function Tokenizer(options, cbs){
 	this._ended = false;
 	this._xmlMode = !!(options && options.xmlMode);
 	this._decodeEntities = !!(options && options.decodeEntities);
+  this._suspended = false;
+}
+
+Tokenizer.prototype.suspend = function(suspended) {
+  this._suspended = suspended;
 }
 
 Tokenizer.prototype._stateText = function(c){
@@ -229,6 +234,7 @@ Tokenizer.prototype._stateBeforeAttributeName = function(c){
 	if(c === ">"){
 		this._cbs.onopentagend();
 		this._state = TEXT;
+
 		this._sectionStart = this._index + 1;
 	} else if(c === "/"){
 		this._state = IN_SELF_CLOSING_TAG;
@@ -633,8 +639,15 @@ Tokenizer.prototype.write = function(chunk){
 };
 
 Tokenizer.prototype._parse = function(){
+  var prevIndex = -1;
 	while(this._index < this._buffer.length && this._running){
 		var c = this._buffer.charAt(this._index);
+
+    if (this._emitRawChars === true && this._cbs.onrawchar && this._index !== prevIndex) {
+      prevIndex = this._index;
+      this._cbs.onrawchar(c);
+    }
+
 		if(this._state === TEXT) {
 			this._stateText(c);
 		} else if(this._state === BEFORE_TAG_NAME){
@@ -904,3 +917,8 @@ Tokenizer.prototype._emitPartial = function(value){
 		this._cbs.ontext(value);
 	}
 };
+
+// Tell the tokenizer to start emitting raw characters
+Tokenizer.prototype.emitRawChars = function(value) {
+  this._emitRawChars = value;
+}

--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -144,11 +144,6 @@ function Tokenizer(options, cbs){
 	this._ended = false;
 	this._xmlMode = !!(options && options.xmlMode);
 	this._decodeEntities = !!(options && options.decodeEntities);
-  this._suspended = false;
-}
-
-Tokenizer.prototype.suspend = function(suspended) {
-  this._suspended = suspended;
 }
 
 Tokenizer.prototype._stateText = function(c){
@@ -639,14 +634,14 @@ Tokenizer.prototype.write = function(chunk){
 };
 
 Tokenizer.prototype._parse = function(){
-  var prevIndex = -1;
+	var prevIndex = -1;
 	while(this._index < this._buffer.length && this._running){
 		var c = this._buffer.charAt(this._index);
 
-    if (this._emitRawChars === true && this._cbs.onrawchar && this._index !== prevIndex) {
-      prevIndex = this._index;
-      this._cbs.onrawchar(c);
-    }
+		if(this._emitRawChars === true && this._cbs.onrawchar && this._index !== prevIndex) {
+			prevIndex = this._index;
+			this._cbs.onrawchar(c);
+		}
 
 		if(this._state === TEXT) {
 			this._stateText(c);
@@ -919,6 +914,6 @@ Tokenizer.prototype._emitPartial = function(value){
 };
 
 // Tell the tokenizer to start emitting raw characters
-Tokenizer.prototype.emitRawChars = function(value) {
-  this._emitRawChars = value;
-}
+Tokenizer.prototype.emitRawChars = function(value){
+	this._emitRawChars = value;
+};

--- a/test/api.js
+++ b/test/api.js
@@ -1,5 +1,5 @@
 var htmlparser2 = require(".."),
-    assert = require("assert");
+		assert = require("assert");
 
 describe("API", function(){
 
@@ -89,53 +89,53 @@ describe("API", function(){
 		p.done();
 	});
 
-  describe("should not parse code blocks", function() {
-    it("with no attributes on code tag", function() {
-      var html = "<code><Span /><Div className=\"foo\">inner</Div></code><div>back to usual</div>";
-      var output = '';
+	describe("should not parse code blocks", function(){
+		it("with no attributes on code tag", function(){
+			var html = "<code><Span /><Div className=\"foo\">inner</Div></code><h1>header</h1><code><Component prop=\"5\"/></code><span>after</span>";
+			var output = "";
 
-      var p = new htmlparser2.Parser({
-        onopentagname: function(name) {
-          output += '<' + name + '>';
-        },
-        onclosetag: function(name) {
-          output += '</' + name + '>';
-        },
-        ontext: function(text) {
-          output += text;
-        }
-      }, {
-        doNotParseCodeBlocks: true
-      });
-      p.write(html);
+			var p = new htmlparser2.Parser({
+				onopentagname: function(name){
+					output += "<" + name + ">";
+				},
+				onclosetag: function(name){
+					output += "</" + name + ">";
+				},
+				ontext: function(text){
+					output += text;
+				}
+			}, {
+				doNotParseCodeBlocks: true
+			});
+			p.write(html);
 
-      assert.equal(output, html);
-    });
+			assert.equal(output, html);
+		});
 
-    it("with attributes on code block", function() {
-      var html = "<code lang=\"javascript\"><Span /><Div className=\"foo\">inner</Div></code><div>back to usual</div>";
-      var output = '';
+		it("with attributes on code block", function(){
+			var html = "<code lang=\"javascript\"><Span /><Div className=\"foo\">inner</Div></code><div>back to usual</div>";
+			var output = "";
 
-      var p = new htmlparser2.Parser({
-        onopentag: function(name, attribs) {
-          output += '<' + name;
-          for (key in attribs) {
-            output += ' ' + key + '="' + attribs[key] + '"';
-          }
-          output += '>';
-        },
-        onclosetag: function(name) {
-          output += '</' + name + '>';
-        },
-        ontext: function(text) {
-          output += text;
-        }
-      }, {
-        doNotParseCodeBlocks: true
-      });
-      p.write(html);
+			var p = new htmlparser2.Parser({
+				onopentag: function(name, attribs){
+					output += "<" + name;
+					for(var key in attribs){
+						output += " " + key + "=\"" + attribs[key] + "\"";
+					}
+					output += ">";
+				},
+				onclosetag: function(name){
+					output += "</" + name + ">";
+				},
+				ontext: function(text){
+					output += text;
+				}
+			}, {
+				doNotParseCodeBlocks: true
+			});
+			p.write(html);
 
-      assert.equal(output, html);
-    });
-  });
+			assert.equal(output, html);
+		});
+	});
 });

--- a/test/api.js
+++ b/test/api.js
@@ -88,4 +88,54 @@ describe("API", function(){
 		}, { Tokenizer: CustomTokenizer });
 		p.done();
 	});
+
+  describe("should not parse code blocks", function() {
+    it("with no attributes on code tag", function() {
+      var html = "<code><Span /><Div className=\"foo\">inner</Div></code><div>back to usual</div>";
+      var output = '';
+
+      var p = new htmlparser2.Parser({
+        onopentagname: function(name) {
+          output += '<' + name + '>';
+        },
+        onclosetag: function(name) {
+          output += '</' + name + '>';
+        },
+        ontext: function(text) {
+          output += text;
+        }
+      }, {
+        doNotParseCodeBlocks: true
+      });
+      p.write(html);
+
+      assert.equal(output, html);
+    });
+
+    it("with attributes on code block", function() {
+      var html = "<code lang=\"javascript\"><Span /><Div className=\"foo\">inner</Div></code><div>back to usual</div>";
+      var output = '';
+
+      var p = new htmlparser2.Parser({
+        onopentag: function(name, attribs) {
+          output += '<' + name;
+          for (key in attribs) {
+            output += ' ' + key + '="' + attribs[key] + '"';
+          }
+          output += '>';
+        },
+        onclosetag: function(name) {
+          output += '</' + name + '>';
+        },
+        ontext: function(text) {
+          output += text;
+        }
+      }, {
+        doNotParseCodeBlocks: true
+      });
+      p.write(html);
+
+      assert.equal(output, html);
+    });
+  });
 });


### PR DESCRIPTION
I have a module [htmlprep](https://github.com/4front/htmlprep) that is a lightweight html pre-processor. It depends on htmlparser2 to process an input stream of html text and emit events like `onopentag`, `onclosetag`, `ontext`, etc. It works great, the only problem I've encountered is preserving the verbatim contents of `<code/>` tags, specifically React JSX code snippets that are interpreted as HTML but actually play by different rules. Most critically any React component can be a self-closing tag, for example `<SpecialButton />` is perfectly valid JSX.

My solution to this is to define a new option `doNotParseCodeBlocks` that if set to `true` detects when the stream enters a `<code>` tag. The `Parser` then sets a property on the `Tokenizer` to start emitting a new event `onrawchar` that sends back the actual character (in addition to the regular tokenizing behavior). The `Parser` buffers up all the raw characters while inside the `<code>` tag.  Finally when the `Parser` detects the matching `</code>` tag, it tells the `Tokenizer` to stop emitting raw chars and flushes  the buffered content in a `ontext` callback.

This shouldn't have any perceptible impact on performance when `doNotParseCodeBlocks` is not explicitly set to `true`.

If this is logic is too specialized, I can maintain a fork, but wanted to give you the chance to consider merging.

Thanks for the great library.
