### PR TITLE
Replace util.inherits

### DIFF
--- a/lib/FeedHandler.js
+++ b/lib/FeedHandler.js
@@ -7,7 +7,7 @@ function FeedHandler(callback, options){
 	this.init(callback, options);
 }
 
-require("util").inherits(FeedHandler, DomHandler);
+require("inherits")(FeedHandler, DomHandler);
 
 FeedHandler.prototype.init = DomHandler;
 

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -119,7 +119,7 @@ function Parser(cbs, options){
 	if(this._cbs.onparserinit) this._cbs.onparserinit(this);
 }
 
-require("util").inherits(Parser, require("events").EventEmitter);
+require("inherits")(Parser, require("events").EventEmitter);
 
 Parser.prototype._updatePosition = function(initialOffset){
 	if(this.endIndex === null){

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -6,7 +6,7 @@ function Stream(options){
 	Parser.call(this, new Cbs(this), options);
 }
 
-require("util").inherits(Stream, Parser);
+require("inherits")(Stream, Parser);
 
 Stream.prototype.readable = true;
 

--- a/lib/WritableStream.js
+++ b/lib/WritableStream.js
@@ -13,7 +13,7 @@ function Stream(cbs, options){
 	});
 }
 
-require("util").inherits(Stream, WritableStream);
+require("inherits")(Stream, WritableStream);
 
 WritableStream.prototype._write = function(chunk, encoding, cb){
 	this._parser.write(chunk);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "domhandler": "^2.3.0",
     "domutils": "^1.5.1",
     "entities": "^1.1.1",
+    "inherits": "^2.0.1",
     "readable-stream": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,

I replaced `require("util").inherits` by `require("inherits")` which is more consistent with `readable-stream` usage and produce a smaller [browserify](http://browserify.org/) build.

`inherits` is already a `readable-stream` dependency.

Thank for your job on this lib ;)