### PR TITLE
Consider "<" before checking if in a special

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -166,6 +166,9 @@ Tokenizer.prototype._stateText = function(c){
 Tokenizer.prototype._stateBeforeTagName = function(c){
 	if(c === "/"){
 		this._state = BEFORE_CLOSING_TAG_NAME;
+	} else if(c === "<"){
+		this._cbs.ontext(this._getSection());
+		this._sectionStart = this._index;
 	} else if(c === ">" || this._special !== SPECIAL_NONE || whitespace(c)) {
 		this._state = TEXT;
 	} else if(c === "!"){
@@ -174,9 +177,6 @@ Tokenizer.prototype._stateBeforeTagName = function(c){
 	} else if(c === "?"){
 		this._state = IN_PROCESSING_INSTRUCTION;
 		this._sectionStart = this._index + 1;
-	} else if(c === "<"){
-		this._cbs.ontext(this._getSection());
-		this._sectionStart = this._index;
 	} else {
 		this._state = (!this._xmlMode && (c === "s" || c === "S")) ?
 						BEFORE_SPECIAL : IN_TAG_NAME;

--- a/test/Events/32-script-ending-with-lessthan.json
+++ b/test/Events/32-script-ending-with-lessthan.json
@@ -1,0 +1,35 @@
+{
+  "name": "Scripts ending with <",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "<script><</script>",
+  "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "script"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "script",
+        {}
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "<"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "script"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This ensures that we catch the close tag when the special ends with a "<".  Fixes #165.