### PR TITLE
Fix #156: do not close what we never open

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -300,11 +300,17 @@ Parser.prototype.onerror = function(err){
 
 Parser.prototype.onend = function(){
 	if(this._cbs.onclosetag){
-		for(
-			var i = this._stack.length;
-			i > 0;
-			this._cbs.onclosetag(this._stack[--i])
-		);
+		var i = this._stack.length;
+		while(i > 0) {
+			// If onopentagnameend hasn't happened yet, then don't
+			// try to close it, as there has been no opentag event
+			if(this._tagname) {
+				this._tagname = "";
+				i--;
+				continue;
+			}
+			this._cbs.onclosetag(this._stack[--i]);
+		}
 	}
 	if(this._cbs.onend) this._cbs.onend();
 };

--- a/test/Events/33-do-not-close-what-we-never-open.json
+++ b/test/Events/33-do-not-close-what-we-never-open.json
@@ -32,19 +32,6 @@
       ]
     },
     {
-      "event": "opentag",
-      "data": [
-        "a",
-        {}
-      ]
-    },
-    {
-      "event": "closetag",
-      "data": [
-        "a"
-      ]
-    },
-    {
       "event": "closetag",
       "data": [
         "p"

--- a/test/Events/33-do-not-close-what-we-never-open.json
+++ b/test/Events/33-do-not-close-what-we-never-open.json
@@ -1,0 +1,54 @@
+{
+  "name": "Do not close what we never open",
+  "options": {
+    "handler": {},
+    "parser": {}
+  },
+  "html": "<p>Hey! Here is a broken link tag: <a href=\"http://www.example.com/lel...",
+  "expected": [
+    {
+      "event": "opentagname",
+      "data": [
+        "p"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "p",
+        {}
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "Hey! Here is a broken link tag: "
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": [
+        "a"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "a",
+        {}
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "a"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "p"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The actual bug is that the "A" tag gets closed but never opened.

It would also be fine if htmlparser2 discarded the busted "A" tag entirely.

For this test I just had to guess that your preferred outcome would be to open it, since we close it.
