### PR TITLE
Fixed write() problem

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -606,13 +606,13 @@ Tokenizer.prototype._cleanup = function (){
 				this._cbs.ontext(this._buffer.substr(this._sectionStart));
 			}
 			this._buffer = "";
-			this._index = 0;
 			this._bufferOffset += this._index;
+			this._index = 0;
 		} else if(this._sectionStart === this._index){
 			//the section just started
 			this._buffer = "";
-			this._index = 0;
 			this._bufferOffset += this._index;
+			this._index = 0;
 		} else {
 			//remove everything unnecessary
 			this._buffer = this._buffer.substr(this._sectionStart);


### PR DESCRIPTION
I had some problem in multiple write

```
doc.write(arg) ;
doc.write(arg1) ;
doc.write(arg2) ;
doc.write(arg3) ;
```
by looking at the code it seems it was due to 
```
this._index = 0;
this._bufferOffset += this._index;
```
which is obviously wrong.
by switching them to:

```
this._bufferOffset += this._index;
this._index = 0;
```
It worked. 
Here's my pull request.