### PR TITLE
Fix startIndex/endIndex when a tag is spread across multiple chunks

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -598,8 +598,8 @@ Tokenizer.prototype._stateInHexEntity = function(c){
 Tokenizer.prototype._cleanup = function (){
 	if(this._sectionStart < 0){
 		this._buffer = "";
-		this._index = 0;
 		this._bufferOffset += this._index;
+		this._index = 0;
 	} else if(this._running){
 		if(this._state === TEXT){
 			if(this._sectionStart !== this._index){

--- a/test/api.js
+++ b/test/api.js
@@ -67,10 +67,22 @@ describe("API", function(){
 		p.write("foo");
 
 		assert.equal(p.startIndex, 0);
+		assert.equal(p.endIndex, 2);
 
 		p.write("<bar>");
 
 		assert.equal(p.startIndex, 3);
+		assert.equal(p.endIndex, 7);
+	});
+
+	it("should update the position when a single tag is spread across multiple chunks", function(){
+		var p = new htmlparser2.Parser(null);
+
+		p.write("<div ");
+		p.write("foo=bar>");
+
+		assert.equal(p.startIndex, 0);
+		assert.equal(p.endIndex, 12);
 	});
 
 	it("should support custom tokenizer", function(){


### PR DESCRIPTION
@gustavnikolaj and I ran into a problem where `endIndex` came out wrong for a tag that spanned multiple chunks. We tracked it down to something that looks like an obvious mistake.