### PR TITLE
Remove require for stream

### DIFF
--- a/lib/WritableStream.js
+++ b/lib/WritableStream.js
@@ -1,7 +1,7 @@
 module.exports = Stream;
 
 var Parser = require("./Parser.js");
-var WritableStream = require("stream").Writable || require("readable-stream").Writable;
+var WritableStream = require("readable-stream").Writable;
 var StringDecoder = require("string_decoder").StringDecoder;
 var Buffer = require("buffer").Buffer;
 


### PR DESCRIPTION
According to the official repository of [nodejs/readable-stream](https://github.com/nodejs/readable-stream):
If you want to guarantee a stable streams base, regardless of what version of Node you, or the users of your libraries are using, use readable-stream only and avoid the "stream" module in Node-core.

Also, stream module does not exist anymore in Node 9+, breaking the library.