### PR TITLE
Fix premature cdata end detection with conditional comments

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -88,12 +88,6 @@ function whitespace(c){
 	return c === " " || c === "\n" || c === "\t" || c === "\f" || c === "\r";
 }
 
-function characterState(char, SUCCESS){
-	return function(c){
-		if(c === char) this._state = SUCCESS;
-	};
-}
-
 function ifElseState(upper, SUCCESS, FAILURE){
 	var lower = upper.toLowerCase();
 
@@ -401,7 +395,10 @@ Tokenizer.prototype._stateInCdata = function(c){
 	if(c === "]") this._state = AFTER_CDATA_1;
 };
 
-Tokenizer.prototype._stateAfterCdata1 = characterState("]", AFTER_CDATA_2);
+Tokenizer.prototype._stateAfterCdata1 = function(c){
+	if(c === "]") this._state = AFTER_CDATA_2;
+	else this._state = IN_CDATA;
+};
 
 Tokenizer.prototype._stateAfterCdata2 = function(c){
 	if(c === ">"){

--- a/test/Events/33-cdata_more-edge-cases.json
+++ b/test/Events/33-cdata_more-edge-cases.json
@@ -1,0 +1,12 @@
+{
+  "name": "CDATA more edge-cases",
+  "options": {
+    "parser": {"recognizeCDATA": true}
+  },
+  "html": "<![CDATA[foo]bar]>baz]]>",
+  "expected": [
+    { "event": "cdatastart", "data": [] },
+    { "event": "text",     "data": [ "foo]bar]>baz" ] },
+    { "event": "cdataend",  "data": [] }
+  ]
+}


### PR DESCRIPTION
The tokenizer stays in the AFTER_CDATA1 state after detecting a closing square bracket, even if no additional square and angled bracket follow. So it will detect any following square and angular bracket as CDATA end, even if there are arbitrary characters in between them.

In the scenario where a CDATA section includes multiple conditional comments (`<!--[if mso]>...<![endif]--> ... <!--[if mso]>...<![endif]-->`), the tokenizer will break out of the cdata section after it encounters the second `]>`. Please see the test case i added for this.

I fixed this by going back to the IN_CDATA state if no additional square bracket follows after the first one.

