### PR TITLE
Change Tokenizer require location to prevent errors with 'inline-requires' babel plugin.

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1,4 +1,4 @@
-var Tokenizer = require("./Tokenizer.js");
+var Tokenizer;
 
 /*
 	Options:
@@ -114,6 +114,8 @@ function Parser(cbs, options){
 
 	if(this._options.Tokenizer) {
 		Tokenizer = this._options.Tokenizer;
+	} else {
+		Tokenizer = require("./Tokenizer.js");	
 	}
 	this._tokenizer = new Tokenizer(this._options, this);
 


### PR DESCRIPTION
Error message:

```
error: bundling failed: "TransformError: /Users/douglas/projetos/ReactNative/aquasafe-mobile/node_modules/htmlparser2-without-node-native/lib/Parser.js: /Users/douglas/projetos/ReactNative/aquasafe-mobile/node_modules/htmlparser2-without-node-native/lib/Parser.js: Cannot assign to a require(...) alias, Tokenizer. Line: 115."
```

Plugin source: https://github.com/facebook/fbjs/blob/master/packages/babel-preset-fbjs/plugins/inline-requires.js

The 'inline-requires' babel plugin allows the modules to be loaded on demand, avoiding an initial delay to start the react native app. And then, the error occurs because the Plugin replaces the use of the `var Tokenizer` with `require("./Tokenizer.js")`. 

In the original code, the plugin replaces this:

```js
var Tokenizer = require("./Tokenizer.js");
// ...
Tokenizer = this._options.Tokenizer;
// ...
```

For this:

```js
// ...
require("./Tokenizer.js") = this._options.Tokenizer;
// ...
```
