### PR TITLE
Make tokenizer track line number and report in callbacks.

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -139,7 +139,7 @@ Parser.prototype.ontext = function(data){
 	this._updatePosition(1);
 	this.endIndex--;
 
-	if(this._cbs.ontext) this._cbs.ontext(data);
+	if(this._cbs.ontext) this._cbs.ontext(data, this._tokenizer._line);
 };
 
 Parser.prototype.onopentagname = function(name){
@@ -153,7 +153,7 @@ Parser.prototype.onopentagname = function(name){
 		for(
 			var el;
 			(el = this._stack[this._stack.length - 1]) in openImpliesClose[name];
-			this.onclosetag(el)
+			this.onclosetag(el, this._tokenizer._line)
 		);
 	}
 
@@ -161,7 +161,7 @@ Parser.prototype.onopentagname = function(name){
 		this._stack.push(name);
 	}
 
-	if(this._cbs.onopentagname) this._cbs.onopentagname(name);
+	if(this._cbs.onopentagname) this._cbs.onopentagname(name, this._tokenizer._line);
 	if(this._cbs.onopentag) this._attribs = {};
 };
 
@@ -169,12 +169,12 @@ Parser.prototype.onopentagend = function(){
 	this._updatePosition(1);
 
 	if(this._attribs){
-		if(this._cbs.onopentag) this._cbs.onopentag(this._tagname, this._attribs);
+		if(this._cbs.onopentag) this._cbs.onopentag(this._tagname, this._attribs, this._tokenizer._line);
 		this._attribs = null;
 	}
 
 	if(!this._options.xmlMode && this._cbs.onclosetag && this._tagname in voidElements){
-		this._cbs.onclosetag(this._tagname);
+		this._cbs.onclosetag(this._tagname, this._tokenizer._line);
 	}
 
 	this._tagname = "";
@@ -192,15 +192,15 @@ Parser.prototype.onclosetag = function(name){
 		if(pos !== -1){
 			if(this._cbs.onclosetag){
 				pos = this._stack.length - pos;
-				while(pos--) this._cbs.onclosetag(this._stack.pop());
+				while(pos--) this._cbs.onclosetag(this._stack.pop(), this._tokenizer._line);
 			}
 			else this._stack.length = pos;
 		} else if(name === "p" && !this._options.xmlMode){
-			this.onopentagname(name);
+			this.onopentagname(name, this._tokenizer._line);
 			this._closeCurrentTag();
 		}
 	} else if(!this._options.xmlMode && (name === "br" || name === "p")){
-		this.onopentagname(name);
+		this.onopentagname(name, this._tokenizer._line);
 		this._closeCurrentTag();
 	}
 };
@@ -209,20 +209,20 @@ Parser.prototype.onselfclosingtag = function(){
 	if(this._options.xmlMode || this._options.recognizeSelfClosing){
 		this._closeCurrentTag();
 	} else {
-		this.onopentagend();
+		this.onopentagend(this._tokenizer._line);
 	}
 };
 
 Parser.prototype._closeCurrentTag = function(){
 	var name = this._tagname;
 
-	this.onopentagend();
+	this.onopentagend(this._tokenizer._line);
 
 	//self-closing tags will be on the top of the stack
 	//(cheaper check than in onclosetag)
 	if(this._stack[this._stack.length - 1] === name){
 		if(this._cbs.onclosetag){
-			this._cbs.onclosetag(name);
+			this._cbs.onclosetag(name, this._tokenizer._line);
 		}
 		this._stack.pop();
 	}
@@ -240,7 +240,7 @@ Parser.prototype.onattribdata = function(value){
 };
 
 Parser.prototype.onattribend = function(){
-	if(this._cbs.onattribute) this._cbs.onattribute(this._attribname, this._attribvalue);
+	if(this._cbs.onattribute) this._cbs.onattribute(this._attribname, this._attribvalue, this._tokenizer._line);
 	if(
 		this._attribs &&
 		!Object.prototype.hasOwnProperty.call(this._attribs, this._attribname)
@@ -265,38 +265,38 @@ Parser.prototype._getInstructionName = function(value){
 Parser.prototype.ondeclaration = function(value){
 	if(this._cbs.onprocessinginstruction){
 		var name = this._getInstructionName(value);
-		this._cbs.onprocessinginstruction("!" + name, "!" + value);
+		this._cbs.onprocessinginstruction("!" + name, "!" + value, this._tokenizer._line);
 	}
 };
 
 Parser.prototype.onprocessinginstruction = function(value){
 	if(this._cbs.onprocessinginstruction){
 		var name = this._getInstructionName(value);
-		this._cbs.onprocessinginstruction("?" + name, "?" + value);
+		this._cbs.onprocessinginstruction("?" + name, "?" + value, this._tokenizer._line);
 	}
 };
 
 Parser.prototype.oncomment = function(value){
 	this._updatePosition(4);
 
-	if(this._cbs.oncomment) this._cbs.oncomment(value);
-	if(this._cbs.oncommentend) this._cbs.oncommentend();
+	if(this._cbs.oncomment) this._cbs.oncomment(value, this._tokenizer._line);
+	if(this._cbs.oncommentend) this._cbs.oncommentend(this._tokenizer._line);
 };
 
 Parser.prototype.oncdata = function(value){
 	this._updatePosition(1);
 
 	if(this._options.xmlMode || this._options.recognizeCDATA){
-		if(this._cbs.oncdatastart) this._cbs.oncdatastart();
-		if(this._cbs.ontext) this._cbs.ontext(value);
-		if(this._cbs.oncdataend) this._cbs.oncdataend();
+		if(this._cbs.oncdatastart) this._cbs.oncdatastart(this._tokenizer._line);
+		if(this._cbs.ontext) this._cbs.ontext(value, this._tokenizer._line);
+		if(this._cbs.oncdataend) this._cbs.oncdataend(this._tokenizer._line);
 	} else {
-		this.oncomment("[CDATA[" + value + "]]");
+		this.oncomment("[CDATA[" + value + "]]", this._tokenizer._line);
 	}
 };
 
 Parser.prototype.onerror = function(err){
-	if(this._cbs.onerror) this._cbs.onerror(err);
+	if(this._cbs.onerror) this._cbs.onerror(err, this._tokenizer._line);
 };
 
 Parser.prototype.onend = function(){
@@ -304,16 +304,16 @@ Parser.prototype.onend = function(){
 		for(
 			var i = this._stack.length;
 			i > 0;
-			this._cbs.onclosetag(this._stack[--i])
+			this._cbs.onclosetag(this._stack[--i], this._tokenizer._line)
 		);
 	}
-	if(this._cbs.onend) this._cbs.onend();
+	if(this._cbs.onend) this._cbs.onend(this._tokenizer._line);
 };
 
 
 //Resets the parser to a blank state, ready to parse a new HTML document
 Parser.prototype.reset = function(){
-	if(this._cbs.onreset) this._cbs.onreset();
+	if(this._cbs.onreset) this._cbs.onreset(this._tokenizer._line);
 	this._tokenizer.reset();
 
 	this._tagname = "";
@@ -321,7 +321,7 @@ Parser.prototype.reset = function(){
 	this._attribs = null;
 	this._stack = [];
 
-	if(this._cbs.onparserinit) this._cbs.onparserinit(this);
+	if(this._cbs.onparserinit) this._cbs.onparserinit(this, this._tokenizer._line);
 };
 
 //Parses a complete HTML document and pushes it to the handler

--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -138,22 +138,25 @@ function Tokenizer(options, cbs){
 	this._ended = false;
 	this._xmlMode = !!(options && options.xmlMode);
 	this._decodeEntities = !!(options && options.decodeEntities);
+	this._line = 1
 }
 
 Tokenizer.prototype._stateText = function(c){
 	if(c === "<"){
 		if(this._index > this._sectionStart){
-			this._cbs.ontext(this._getSection());
+			this._cbs.ontext(this._getSection(), this._line);
 		}
 		this._state = BEFORE_TAG_NAME;
 		this._sectionStart = this._index;
 	} else if(this._decodeEntities && this._special === SPECIAL_NONE && c === "&"){
 		if(this._index > this._sectionStart){
-			this._cbs.ontext(this._getSection());
+			this._cbs.ontext(this._getSection(), this._line);
 		}
 		this._baseState = TEXT;
 		this._state = BEFORE_ENTITY;
 		this._sectionStart = this._index;
+	} else if(this._line && c === "\n" || (c === "\r" && this._buffer.charAt(this._index - 1) !== "\n")){
+		this._line++;
 	}
 };
 
@@ -161,7 +164,7 @@ Tokenizer.prototype._stateBeforeTagName = function(c){
 	if(c === "/"){
 		this._state = BEFORE_CLOSING_TAG_NAME;
 	} else if(c === "<"){
-		this._cbs.ontext(this._getSection());
+		this._cbs.ontext(this._getSection(), this._line);
 		this._sectionStart = this._index;
 	} else if(c === ">" || this._special !== SPECIAL_NONE || whitespace(c)) {
 		this._state = TEXT;
@@ -221,7 +224,7 @@ Tokenizer.prototype._stateAfterCloseingTagName = function(c){
 
 Tokenizer.prototype._stateBeforeAttributeName = function(c){
 	if(c === ">"){
-		this._cbs.onopentagend();
+		this._cbs.onopentagend(this._line);
 		this._state = TEXT;
 		this._sectionStart = this._index + 1;
 	} else if(c === "/"){
@@ -234,7 +237,7 @@ Tokenizer.prototype._stateBeforeAttributeName = function(c){
 
 Tokenizer.prototype._stateInSelfClosingTag = function(c){
 	if(c === ">"){
-		this._cbs.onselfclosingtag();
+		this._cbs.onselfclosingtag(this._line);
 		this._state = TEXT;
 		this._sectionStart = this._index + 1;
 	} else if(!whitespace(c)){
@@ -245,7 +248,7 @@ Tokenizer.prototype._stateInSelfClosingTag = function(c){
 
 Tokenizer.prototype._stateInAttributeName = function(c){
 	if(c === "=" || c === "/" || c === ">" || whitespace(c)){
-		this._cbs.onattribname(this._getSection());
+		this._cbs.onattribname(this._getSection(), this._line);
 		this._sectionStart = -1;
 		this._state = AFTER_ATTRIBUTE_NAME;
 		this._index--;
@@ -256,11 +259,11 @@ Tokenizer.prototype._stateAfterAttributeName = function(c){
 	if(c === "="){
 		this._state = BEFORE_ATTRIBUTE_VALUE;
 	} else if(c === "/" || c === ">"){
-		this._cbs.onattribend();
+		this._cbs.onattribend(this._line);
 		this._state = BEFORE_ATTRIBUTE_NAME;
 		this._index--;
 	} else if(!whitespace(c)){
-		this._cbs.onattribend();
+		this._cbs.onattribend(this._line);
 		this._state = IN_ATTRIBUTE_NAME;
 		this._sectionStart = this._index;
 	}
@@ -283,7 +286,7 @@ Tokenizer.prototype._stateBeforeAttributeValue = function(c){
 Tokenizer.prototype._stateInAttributeValueDoubleQuotes = function(c){
 	if(c === "\""){
 		this._emitToken("onattribdata");
-		this._cbs.onattribend();
+		this._cbs.onattribend(this._line);
 		this._state = BEFORE_ATTRIBUTE_NAME;
 	} else if(this._decodeEntities && c === "&"){
 		this._emitToken("onattribdata");
@@ -296,7 +299,7 @@ Tokenizer.prototype._stateInAttributeValueDoubleQuotes = function(c){
 Tokenizer.prototype._stateInAttributeValueSingleQuotes = function(c){
 	if(c === "'"){
 		this._emitToken("onattribdata");
-		this._cbs.onattribend();
+		this._cbs.onattribend(this._line);
 		this._state = BEFORE_ATTRIBUTE_NAME;
 	} else if(this._decodeEntities && c === "&"){
 		this._emitToken("onattribdata");
@@ -309,7 +312,7 @@ Tokenizer.prototype._stateInAttributeValueSingleQuotes = function(c){
 Tokenizer.prototype._stateInAttributeValueNoQuotes = function(c){
 	if(whitespace(c) || c === ">"){
 		this._emitToken("onattribdata");
-		this._cbs.onattribend();
+		this._cbs.onattribend(this._line);
 		this._state = BEFORE_ATTRIBUTE_NAME;
 		this._index--;
 	} else if(this._decodeEntities && c === "&"){
@@ -328,7 +331,7 @@ Tokenizer.prototype._stateBeforeDeclaration = function(c){
 
 Tokenizer.prototype._stateInDeclaration = function(c){
 	if(c === ">"){
-		this._cbs.ondeclaration(this._getSection());
+		this._cbs.ondeclaration(this._getSection(), this._line);
 		this._state = TEXT;
 		this._sectionStart = this._index + 1;
 	}
@@ -336,7 +339,7 @@ Tokenizer.prototype._stateInDeclaration = function(c){
 
 Tokenizer.prototype._stateInProcessingInstruction = function(c){
 	if(c === ">"){
-		this._cbs.onprocessinginstruction(this._getSection());
+		this._cbs.onprocessinginstruction(this._getSection(), this._line);
 		this._state = TEXT;
 		this._sectionStart = this._index + 1;
 	}
@@ -366,7 +369,7 @@ Tokenizer.prototype._stateAfterComment1 = function(c){
 Tokenizer.prototype._stateAfterComment2 = function(c){
 	if(c === ">"){
 		//remove 2 trailing chars
-		this._cbs.oncomment(this._buffer.substring(this._sectionStart, this._index - 2));
+		this._cbs.oncomment(this._buffer.substring(this._sectionStart, this._index - 2), this._line);
 		this._state = TEXT;
 		this._sectionStart = this._index + 1;
 	} else if(c !== "-"){
@@ -403,7 +406,7 @@ Tokenizer.prototype._stateAfterCdata1 = function(c){
 Tokenizer.prototype._stateAfterCdata2 = function(c){
 	if(c === ">"){
 		//remove 2 trailing chars
-		this._cbs.oncdata(this._buffer.substring(this._sectionStart, this._index - 2));
+		this._cbs.oncdata(this._buffer.substring(this._sectionStart, this._index - 2), this._line);
 		this._state = TEXT;
 		this._sectionStart = this._index + 1;
 	} else if(c !== "]") {
@@ -600,7 +603,7 @@ Tokenizer.prototype._cleanup = function (){
 	} else if(this._running){
 		if(this._state === TEXT){
 			if(this._sectionStart !== this._index){
-				this._cbs.ontext(this._buffer.substr(this._sectionStart));
+				this._cbs.ontext(this._buffer.substr(this._sectionStart), this._line);
 			}
 			this._buffer = "";
 			this._bufferOffset += this._index;
@@ -623,7 +626,7 @@ Tokenizer.prototype._cleanup = function (){
 
 //TODO make events conditional
 Tokenizer.prototype.write = function(chunk){
-	if(this._ended) this._cbs.onerror(Error(".write() after done!"));
+	if(this._ended) this._cbs.onerror(Error(".write() after done!"), this._line);
 
 	this._buffer += chunk;
 	this._parse();
@@ -794,7 +797,7 @@ Tokenizer.prototype._parse = function(){
 		}
 
 		else {
-			this._cbs.onerror(Error("unknown _state"), this._state);
+			this._cbs.onerror(Error("unknown _state"), this._state, this._line);
 		}
 
 		this._index++;
@@ -818,7 +821,7 @@ Tokenizer.prototype.resume = function(){
 };
 
 Tokenizer.prototype.end = function(chunk){
-	if(this._ended) this._cbs.onerror(Error(".end() after done!"));
+	if(this._ended) this._cbs.onerror(Error(".end() after done!"), this._line);
 	if(chunk) this.write(chunk);
 
 	this._ended = true;
@@ -832,16 +835,16 @@ Tokenizer.prototype._finish = function(){
 		this._handleTrailingData();
 	}
 
-	this._cbs.onend();
+	this._cbs.onend(this._line);
 };
 
 Tokenizer.prototype._handleTrailingData = function(){
 	var data = this._buffer.substr(this._sectionStart);
 
 	if(this._state === IN_CDATA || this._state === AFTER_CDATA_1 || this._state === AFTER_CDATA_2){
-		this._cbs.oncdata(data);
+		this._cbs.oncdata(data, this._line);
 	} else if(this._state === IN_COMMENT || this._state === AFTER_COMMENT_1 || this._state === AFTER_COMMENT_2){
-		this._cbs.oncomment(data);
+		this._cbs.oncomment(data, this._line);
 	} else if(this._state === IN_NAMED_ENTITY && !this._xmlMode){
 		this._parseLegacyEntity();
 		if(this._sectionStart < this._index){
@@ -871,7 +874,7 @@ Tokenizer.prototype._handleTrailingData = function(){
 		this._state !== IN_ATTRIBUTE_VALUE_NQ &&
 		this._state !== IN_CLOSING_TAG_NAME
 	){
-		this._cbs.ontext(data);
+		this._cbs.ontext(data, this._line);
 	}
 	//else, ignore remaining data
 	//TODO add a way to remove current tag
@@ -890,14 +893,14 @@ Tokenizer.prototype._getSection = function(){
 };
 
 Tokenizer.prototype._emitToken = function(name){
-	this._cbs[name](this._getSection());
+	this._cbs[name](this._getSection(), this._line);
 	this._sectionStart = -1;
 };
 
 Tokenizer.prototype._emitPartial = function(value){
 	if(this._baseState !== TEXT){
-		this._cbs.onattribdata(value); //TODO implement the new event
+		this._cbs.onattribdata(value, this._line); //TODO implement the new event
 	} else {
-		this._cbs.ontext(value);
+		this._cbs.ontext(value, this._line);
 	}
 };

--- a/test/api.js
+++ b/test/api.js
@@ -100,4 +100,26 @@ describe("API", function(){
 		}, { Tokenizer: CustomTokenizer });
 		p.done();
 	});
+
+	it("should indicate line in each callback", function(){
+		var p = new htmlparser2.Parser({
+			onopentag: function(name, attr, line){
+				assert.equal(line, 1);
+			}
+		},{
+			position: true,
+		});
+
+		p.write("<div></div>");
+
+		p._cbs.onopentag = function(name, attr, line){
+			assert.equal(line, 2);
+		};
+
+		p._cbs.onclosetag = function(name, line){
+			assert.equal(line, 5);
+		};
+
+		p.write("\n<div>\n  Hello\n  World\n  Foobar</div>");
+	});
 });

--- a/test/unicode.js
+++ b/test/unicode.js
@@ -12,8 +12,8 @@ describe("WritableStream", function(){
 			}
 		});
 
-		stream.write(new Buffer([0xE2, 0x82]));
-		stream.write(new Buffer([0xAC]));
+		stream.write(Buffer.from([0xE2, 0x82]));
+		stream.write(Buffer.from([0xAC]));
 		stream.end();
 
 		assert(processed);


### PR DESCRIPTION
I didn't realize people [already raised the issue of tracking the line number](https://github.com/fb55/htmlparser2/issues?utf8=%E2%9C%93&q=line), but here is how I implemented it nonetheless.

I tried to do columns, but realized once the tokenizer/parser has passed over the buffer and done a callback, it's hard to backtrack where the callback's value actually began.  So tracking the column like I've done the line wouldn't be clear. An alternative could be:

```js
position: {
    start: null,
    end: { line: 2, column: 10 }
}
```