### PR TITLE
Remove redundant if statements in Tokenizer

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -532,8 +532,8 @@ Tokenizer.prototype._stateInNamedEntity = function(c){
 		}
 		this._state = this._baseState;
 	} else if((c < "a" || c > "z") && (c < "A" || c > "Z") && (c < "0" || c > "9")){
-		if(this._xmlMode);
-		else if(this._sectionStart + 1 === this._index);
+		if(this._xmlMode) return;
+		else if(this._sectionStart + 1 === this._index) return;
 		else if(this._baseState !== TEXT){
 			if(c !== "="){
 				this._parseNamedEntityStrict();


### PR DESCRIPTION
Explicitly return in if…else blocks

Omitting return statement can cause syntax error 'Unexpected token
else' due to the if statement being interpreted as an expression rather than a statement in some Android os