### PR TITLE
Correctly handle SVG (and MathML) tag closing

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -77,18 +77,25 @@ var voidElements = {
 	source: true,
 	track: true,
 	wbr: true,
-
-	//common self closing svg elements
-	path: true,
-	circle: true,
-	ellipse: true,
-	line: true,
-	rect: true,
-	use: true,
-	stop: true,
-	polyline: true,
-	polygon: true
 };
+
+var foreignContextElements = {
+	__proto__: null,
+	math: true,
+	svg: true
+}
+var htmlIntegrationElements = {
+	__proto__: null,
+	mi: true,
+	mo: true,
+	mn: true,
+	ms: true,
+	mtext: true,
+	"annotation-xml": true,
+	foreignObject: true,
+	desc: true,
+	title: true
+}
 
 var re_nameEnd = /\s|\//;
 
@@ -101,6 +108,7 @@ function Parser(cbs, options){
 	this._attribvalue = "";
 	this._attribs = null;
 	this._stack = [];
+	this._foreignContext = [];
 
 	this.startIndex = 0;
 	this.endIndex = null;
@@ -159,6 +167,8 @@ Parser.prototype.onopentagname = function(name){
 
 	if(this._options.xmlMode || !(name in voidElements)){
 		this._stack.push(name);
+		if(name in foreignContextElements) this._foreignContext.push(true);
+		else if(name in htmlIntegrationElements) this._foreignContext.push(false);
 	}
 
 	if(this._cbs.onopentagname) this._cbs.onopentagname(name);
@@ -206,7 +216,8 @@ Parser.prototype.onclosetag = function(name){
 };
 
 Parser.prototype.onselfclosingtag = function(){
-	if(this._options.xmlMode || this._options.recognizeSelfClosing){
+	if(this._options.xmlMode || this._options.recognizeSelfClosing
+		|| this._foreignContext[this._foreignContext.length - 1]){
 		this._closeCurrentTag();
 	} else {
 		this.onopentagend();
@@ -225,6 +236,9 @@ Parser.prototype._closeCurrentTag = function(){
 			this._cbs.onclosetag(name);
 		}
 		this._stack.pop();
+		if((name in foreignContextElements) || (name in htmlIntegrationElements)){
+			this._foreignContext.pop();
+		}
 	}
 };
 

--- a/test/Documents/Svg.html
+++ b/test/Documents/Svg.html
@@ -8,7 +8,10 @@
 		<animate />
 		<polygon />
 		<g>
-			<path />
+			<path>
+				<title>x</title>
+				<animate />
+			</path>
 		</g>
 	</svg>
 </body>

--- a/test/Stream/06-Svg.json
+++ b/test/Stream/06-Svg.json
@@ -225,6 +225,62 @@
       ]
     },
     {
+      "event": "text",
+      "data": [
+        "\n\t\t\t\t"
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": [
+        "title"
+      ]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "title",
+        {}
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "x"
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": [
+        "title"
+      ]
+    },
+    {
+      "event": "text",
+      "data": [
+        "\n\t\t\t\t"
+      ]
+    },
+    {
+      "event": "opentagname",
+      "data": ["animate"]
+    },
+    {
+      "event": "opentag",
+      "data": [
+        "animate",
+        {}
+      ]
+    },
+    {
+      "event": "closetag",
+      "data": ["animate"]
+    },
+    {
+      "event": "text",
+      "data": ["\n\t\t\t"]
+    },
+    {
       "event": "closetag",
       "data": ["path"]
     },


### PR DESCRIPTION
SVG and MathML elements inside HTML documents always use XML rules for tag closing: any element can have children _or_ can be self-closing with a slash at the end of the start tag.

This PR removes SVG tags from the list of HTML void tags (which was breaking SVG parsing _even with_ `recognizeSelfClosing` set to true). Instead, the code keeps track of the tag names that switch in and out of this "XML-ish" parsing mode (here called `foreignContext` to be consistent with the HTML specs).

Fixes #187 (as well as bugs in various downstream libraries).

Includes tests adapted from PR #129, which is made obsolete. Existing tests, including linting, all still pass.

Note: There are still other issues with SVG/MathML parsing related to case sensitivity. But those can be avoided by setting the [`lowerCaseTags` option](https://github.com/fb55/htmlparser2/wiki/Parser-options#option-lowercasetags) to false.