### PR TITLE
Fix failing context switch 

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -204,6 +204,10 @@ Parser.prototype.onclosetag = function(name) {
     if (this._lowerCaseTagNames) {
         name = name.toLowerCase();
     }
+    
+    if (name in foreignContextElements || name in htmlIntegrationElements) {
+        this._foreignContext.pop();
+    }
 
     if (
         this._stack.length &&
@@ -249,9 +253,7 @@ Parser.prototype._closeCurrentTag = function() {
             this._cbs.onclosetag(name);
         }
         this._stack.pop();
-        if (name in foreignContextElements || name in htmlIntegrationElements) {
-            this._foreignContext.pop();
-        }
+        
     }
 };
 

--- a/test/Documents/Svg.html
+++ b/test/Documents/Svg.html
@@ -5,6 +5,7 @@
 </head>
 <body>
 	<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+		<title>Test</title>
 		<animate />
 		<polygon />
 		<g>

--- a/test/Stream/06-Svg.json
+++ b/test/Stream/06-Svg.json
@@ -1,6 +1,5 @@
 {
     "name": "SVG",
-    "options": { "xmlMode": "auto" },
     "file": "Svg.html",
     "expected": [
         {
@@ -101,6 +100,26 @@
                     "xmlns:xlink": "http://www.w3.org/1999/xlink"
                 }
             ]
+        },
+        {
+            "event": "text",
+            "data": ["\n\t\t"]
+        },
+        {
+            "event": "opentagname",
+            "data": ["title"]
+        },
+        {
+            "event": "opentag",
+            "data": ["title", {}]
+        },
+        {
+            "event": "text",
+            "data": ["Test"]
+        },
+        {
+            "event": "closetag",
+            "data": ["title"]
         },
         {
             "event": "text",


### PR DESCRIPTION
Without this patch the context switches as soon as there's a title tag inside the svg but doesn't switch back on the closing title. So all self-closing svg tags like `path` break.

Relates to #254