### PR TITLE
Fix: Fixed circular dependency

### DIFF
--- a/lib/DomTools.js
+++ b/lib/DomTools.js
@@ -1,0 +1,4 @@
+module.exports = {
+    DomHandler: require("domhandler"),
+    DomUtils: require("domutils")
+};

--- a/lib/FeedHandler.js
+++ b/lib/FeedHandler.js
@@ -1,5 +1,6 @@
-var DomHandler = require("domhandler");
-var DomUtils = require("./DomTools.js").DomUtils;
+var DomTools = require("./DomTools.js");
+var DomHandler = DomTools.DomHandler;
+var DomUtils = DomTools.DomUtils;
 
 //TODO: make this a streamable handler
 function FeedHandler(callback, options) {

--- a/lib/FeedHandler.js
+++ b/lib/FeedHandler.js
@@ -1,5 +1,5 @@
 var DomHandler = require("domhandler");
-var DomUtils = require("domutils");
+var DomUtils = require("./DomTools.js").DomUtils;
 
 //TODO: make this a streamable handler
 function FeedHandler(callback, options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 var Parser = require("./Parser.js");
-var DomHandler = require("domhandler");
+var DomTools = require("./DomTools.js");
+var DomHandler = DomTools.DomHandler;
+var DomUtils = DomTools.DomUtils;
 
 function defineProp(name, value) {
     delete module.exports[name];
@@ -25,7 +27,7 @@ module.exports = {
         return defineProp("ProxyHandler", require("./ProxyHandler.js"));
     },
     get DomUtils() {
-        return defineProp("DomUtils", require("domutils"));
+        return defineProp("DomUtils", DomUtils);
     },
     get CollectingHandler() {
         return defineProp(


### PR DESCRIPTION
This PR fixes the circular dependency in

index.js -> FeedHandler.js -> index.js

Mentioned in [#256](https://github.com/fb55/htmlparser2/issues/256)