### PR TITLE
Remove circular dependencies caused by EVENTS being imported from ./ and ../

### DIFF
--- a/lib/CollectingHandler.js
+++ b/lib/CollectingHandler.js
@@ -5,7 +5,7 @@ function CollectingHandler(cbs) {
     this.events = [];
 }
 
-var EVENTS = require("./").EVENTS;
+var EVENTS = require("./Events");
 Object.keys(EVENTS).forEach(function(name) {
     if (EVENTS[name] === 0) {
         name = "on" + name;

--- a/lib/Events.js
+++ b/lib/Events.js
@@ -1,0 +1,15 @@
+module.exports = {
+    /* Format: eventname: number of arguments */
+    attribute: 2,
+    cdatastart: 0,
+    cdataend: 0,
+    text: 1,
+    processinginstruction: 2,
+    comment: 1,
+    commentend: 0,
+    closetag: 1,
+    opentag: 2,
+    opentagname: 1,
+    error: 1,
+    end: 0
+};

--- a/lib/ProxyHandler.js
+++ b/lib/ProxyHandler.js
@@ -4,7 +4,7 @@ function ProxyHandler(cbs) {
     this._cbs = cbs || {};
 }
 
-var EVENTS = require("./").EVENTS;
+var EVENTS = require("./Events");
 Object.keys(EVENTS).forEach(function(name) {
     if (EVENTS[name] === 0) {
         name = "on" + name;

--- a/lib/Stream.js
+++ b/lib/Stream.js
@@ -14,7 +14,7 @@ function Cbs(scope) {
     this.scope = scope;
 }
 
-var EVENTS = require("../").EVENTS;
+var EVENTS = require("./Events");
 
 Object.keys(EVENTS).forEach(function(name) {
     if (EVENTS[name] === 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var Parser = require("./Parser.js");
 var DomHandler = require("domhandler");
+var EVENTS = require('./Events');
 
 function defineProp(name, value) {
     delete module.exports[name];
@@ -54,19 +55,5 @@ module.exports = {
         return new Parser(handler, options);
     },
     // List of all events that the parser emits
-    EVENTS: {
-        /* Format: eventname: number of arguments */
-        attribute: 2,
-        cdatastart: 0,
-        cdataend: 0,
-        text: 1,
-        processinginstruction: 2,
-        comment: 1,
-        commentend: 0,
-        closetag: 1,
-        opentag: 2,
-        opentagname: 1,
-        error: 1,
-        end: 0
-    }
+    EVENTS: EVENTS
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,14 +2,6 @@ var Parser = require("./Parser.js");
 var DomHandler = require("domhandler");
 var EVENTS = require('./Events');
 
-// rollup brings in too many dependencies for our use case, here is the minimal exports that work
-
-module.exports = {
-    Parser: Parser,
-    DomHandler: DomHandler,
-    EVENTS: EVENTS
-};
-/* Previous exports...
 function defineProp(name, value) {
     delete module.exports[name];
     module.exports[name] = value;
@@ -65,4 +57,3 @@ module.exports = {
     // List of all events that the parser emits
     EVENTS: EVENTS
 };
-*/

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,14 @@ var Parser = require("./Parser.js");
 var DomHandler = require("domhandler");
 var EVENTS = require('./Events');
 
+// rollup brings in too many dependencies for our use case, here is the minimal exports that work
+
+module.exports = {
+    Parser: Parser,
+    DomHandler: DomHandler,
+    EVENTS: EVENTS
+};
+/* Previous exports...
 function defineProp(name, value) {
     delete module.exports[name];
     module.exports[name] = value;
@@ -57,3 +65,4 @@ module.exports = {
     // List of all events that the parser emits
     EVENTS: EVENTS
 };
+*/


### PR DESCRIPTION
rollup throws some warnings for the circular dependencies caused by importing EVENTS from the index.js that imports and re-exports each sub-module.

Warnings:
```
(!) Circular dependency: ../node_modules/htmlparser2/lib/index.js -> ../node_modules/htmlparser2/lib/Stream.js -> ../node_modules/htmlparser2/lib/index.js
(!) Circular dependency: ../node_modules/htmlparser2/lib/index.js -> ../node_modules/htmlparser2/lib/Stream.js -> commonjs-proxy:/Users/grudy/dev/stable/jsapp/node_modules/htmlparser2/lib/index.js -> ../node_modules/htmlparser2/lib/index.js
(!) Circular dependency: ../node_modules/htmlparser2/lib/index.js -> ../node_modules/htmlparser2/lib/ProxyHandler.js -> ../node_modules/htmlparser2/lib/index.js
(!) Circular dependency: ../node_modules/htmlparser2/lib/index.js -> ../node_modules/htmlparser2/lib/CollectingHandler.js -> ../node_modules/htmlparser2/lib/index.js
```

This pull request moves EVENTS into a peer-module that can be imported directly instead of being defined in index.js