### PR TITLE
Add "sideEffects: false" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "description": "Fast & forgiving HTML/XML/RSS parser",
     "version": "4.1.0",
     "author": "Felix Boehm <me@feedic.com>",
+    "sideEffects": false,
     "keywords": [
         "html",
         "parser",


### PR DESCRIPTION
This PR marks `htmlparser2` as free of side effects to allow Webpack to tree shake it if possible. I read through all of the code in this package and didn't spot any side effects, so I think this should be safe.

For more info:
https://webpack.js.org/guides/tree-shaking/
https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking