### PR TITLE
Fix broken parsing after self-closing special tags

### DIFF
--- a/src/Tokenizer.spec.ts
+++ b/src/Tokenizer.spec.ts
@@ -1,0 +1,167 @@
+import { Tokenizer } from ".";
+
+class CallbackLogger {
+    log: string[] = [];
+
+    onattribdata(value: string) {
+        this.log.push(`onattribdata: '${value}'`);
+    }
+    onattribend() {
+        this.log.push(`onattribend`);
+    }
+    onattribname(name: string) {
+        this.log.push(`onattribname: '${name}'`);
+    }
+    oncdata(data: string) {
+        this.log.push(`oncdata: '${data}'`);
+    }
+    onclosetag(name: string) {
+        this.log.push(`onclosetag: '${name}'`);
+    }
+    oncomment(data: string) {
+        this.log.push(`oncomment: '${data}'`);
+    }
+    ondeclaration(content: string) {
+        this.log.push(`ondeclaration: '${content}'`);
+    }
+    onend() {
+        this.log.push(`onend`);
+    }
+    onerror(error: Error, state?: unknown) {
+        this.log.push(`onerror: '${error}', '${state}'`);
+    }
+    onopentagend() {
+        this.log.push(`onopentagend`);
+    }
+    onopentagname(name: string) {
+        this.log.push(`onopentagname: '${name}'`);
+    }
+    onprocessinginstruction(instruction: string) {
+        this.log.push(`onprocessinginstruction: '${instruction}'`);
+    }
+    onselfclosingtag() {
+        this.log.push(`onselfclosingtag`);
+    }
+    ontext(value: string) {
+        this.log.push(`ontext: '${value}'`);
+    }
+}
+
+describe('Tokenizer', () => {
+    test('should support self-closing special tags', () => {
+        const logger = new CallbackLogger();
+        const tokenizer = new Tokenizer({
+            xmlMode: false,
+            decodeEntities: false
+        }, logger);
+
+        const selfClosingScriptInput = '<script /><div></div>';
+        const selfClosingScriptOutput = [
+            "onopentagname: 'script'",
+            'onselfclosingtag',
+            "onopentagname: 'div'",
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(selfClosingScriptInput);
+        tokenizer.end();
+        expect(logger.log).toEqual(selfClosingScriptOutput);
+        tokenizer.reset();
+        logger.log = [];
+
+        const selfClosingStyleInput = '<style /><div></div>';
+        const selfClosingStyleOutput = [
+            "onopentagname: 'style'",
+            'onselfclosingtag',
+            "onopentagname: 'div'",
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(selfClosingStyleInput);
+        tokenizer.end();
+        expect(logger.log).toEqual(selfClosingStyleOutput);
+        tokenizer.reset();
+        logger.log = [];
+
+        const selfClosingTitleInput = '<title /><div></div>';
+        const selfClosingTitleOutput = [
+            "onopentagname: 'title'",
+            'onselfclosingtag',
+            "onopentagname: 'div'",
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(selfClosingTitleInput);
+        tokenizer.end();
+        expect(logger.log).toEqual(selfClosingTitleOutput);
+        tokenizer.reset();
+        logger.log = [];
+       
+    });
+
+    test('should support standard special tags', () => {
+        const logger = new CallbackLogger();
+        const tokenizer = new Tokenizer({
+            xmlMode: false,
+            decodeEntities: false
+        }, logger);
+
+        const normalScriptInput = '<script></script><div></div>';
+        const normalScriptOutput = [
+            "onopentagname: 'script'",
+            'onopentagend',
+            "onclosetag: 'script'",
+            "onopentagname: 'div'",
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(normalScriptInput);
+        tokenizer.end();
+        expect(logger.log).toEqual(normalScriptOutput);
+        tokenizer.reset();
+        logger.log = [];
+        
+        const normalStyleInput = '<style></style><div></div>';
+        const normalStyleOutput = [
+            "onopentagname: 'style'",
+            'onopentagend',
+            "onclosetag: 'style'",
+            "onopentagname: 'div'",
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(normalStyleInput);
+        tokenizer.end();
+        expect(logger.log).toEqual(normalStyleOutput);
+        tokenizer.reset();
+        logger.log = [];
+
+
+        const normalTitleInput = '<title></title><div></div>';
+        const normalTitleOutput = [
+            "onopentagname: 'title'",
+            'onopentagend',
+            "onclosetag: 'title'",
+            "onopentagname: 'div'",
+            'onopentagend',
+            "onclosetag: 'div'",
+            'onend'
+        ];
+
+        tokenizer.write(normalTitleInput);
+        tokenizer.end();
+        expect(logger.log).toEqual(normalTitleOutput);
+        tokenizer.reset();
+        logger.log = [];
+    });
+});

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -372,6 +372,7 @@ export default class Tokenizer {
             this._cbs.onselfclosingtag();
             this._state = State.Text;
             this._sectionStart = this._index + 1;
+            this._special = Special.None; // reset special state, in case of self-closing special tags
         } else if (!whitespace(c)) {
             this._state = State.BeforeAttributeName;
             this._index--;


### PR DESCRIPTION
Currently, self-closing special tags (`<script />`, `<style />`, and `<title />`) are not parsed correctly. The tags will be correctly handled as self-closing, but the rest of the input stream will be parsed as text. Technically self-closing special tags are not valid, but htmlparser2 allows all other tags to be self-closing and its not uncommon to encounter them in malformed HTML or in templates for various frontend frameworks.

**Root Cause:**
When the Tokenizer encounters the end of a self-closing special tag, it correctly issues callbacks for `onopentagname` and `onselfclosingtag`, then returns to the `Text` state. This is consistent with how it handles normal self-closing tags. However, it does not reset the value of `_special` which causes the `Text` state to ignore any additional tags. The Tokenizer will remain in the text state until it happens to encounter a closing tag for the type of special tag that it thinks is currently open.

**Solution:**
Reset `_special` to `Special.None` before leaving the `InSelfClosingTag` state.