### PR TITLE
Coverage

### DIFF
--- a/src/FeedHandler.ts
+++ b/src/FeedHandler.ts
@@ -179,7 +179,7 @@ function addConditionally<T>(
     recurse = false
 ) {
     const tmp = fetch(what, where, recurse);
-    if (tmp) obj[prop] = tmp as any;
+    if (tmp) obj[prop] = tmp as unknown as T[keyof T];
 }
 
 function isValidFeed(value: string) {

--- a/src/Parser.spec.ts
+++ b/src/Parser.spec.ts
@@ -53,6 +53,15 @@ describe("API", () => {
         expect(processed).toBeTruthy();
     });
 
+    test("should work with open-implies-close case of (non-br) void close tag in non-XML mode", () => {
+        const p = new Parser(null, {
+            lowerCaseAttributeNames: true
+        });
+
+        p.write("<select><input></select>");
+        p.done();
+    });
+
     test("should back out of numeric entities (#125)", () => {
         let finished = false;
         let text = "";

--- a/src/Parser.spec.ts
+++ b/src/Parser.spec.ts
@@ -53,15 +53,6 @@ describe("API", () => {
         expect(processed).toBeTruthy();
     });
 
-    test("should work with open-implies-close case of (non-br) void close tag in non-XML mode", () => {
-        const p = new Parser(null, {
-            lowerCaseAttributeNames: true
-        });
-
-        p.write("<select><input></select>");
-        p.done();
-    });
-
     test("should back out of numeric entities (#125)", () => {
         let finished = false;
         let text = "";

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -225,9 +225,7 @@ export class Parser extends EventEmitter {
     //Tokenizer event handlers
     ontext(data: string) {
         this._updatePosition(1);
-        if (this.endIndex !== null) {
-            this.endIndex--;
-        }
+        (this.endIndex as number)--;
         this._cbs.ontext?.(data);
     }
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -242,7 +242,7 @@ export class Parser extends EventEmitter {
         ) {
             for (
                 let el;
-                openImpliesClose[name]?.has(
+                openImpliesClose[name].has(
                     (el = this._stack[this._stack.length - 1])
                 );
                 this.onclosetag(el)

--- a/src/WritableStream.spec.ts
+++ b/src/WritableStream.spec.ts
@@ -7,6 +7,7 @@ describe("WritableStream", () => {
 
         stream.write(Buffer.from([0xe2, 0x82]));
         stream.write(Buffer.from([0xac]));
+        stream.write('');
         stream.end();
 
         expect(ontext).toBeCalledWith("€");

--- a/src/__fixtures__/Events/35-non-br-void-close-tag.json
+++ b/src/__fixtures__/Events/35-non-br-void-close-tag.json
@@ -1,0 +1,33 @@
+{
+    "name": "open-implies-close case of (non-br) void close tag in non-XML mode",
+    "options": {
+        "parser": { "lowerCaseAttributeNames": true }
+    },
+    "html": "<select><input></select>",
+    "expected": [
+        {
+            "event": "opentagname",
+            "data": ["select"]
+        },
+        {
+            "event": "opentag",
+            "data": ["select", {}]
+        },
+        {
+            "event": "closetag",
+            "data": ["select"]
+        },
+        {
+            "event": "opentagname",
+            "data": ["input"]
+        },
+        {
+            "event": "opentag",
+            "data": ["input", {}]
+        },
+        {
+            "event": "closetag",
+            "data": ["input"]
+        }
+    ]
+}

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,7 @@
-import { parseDOM, createDomStream } from ".";
+import {
+    parseDOM, createDomStream, DomHandler, DefaultHandler, RssHandler
+} from ".";
+import { FeedHandler } from "./FeedHandler";
 import { Element } from "domhandler";
 
 // Add an `attributes` prop to the Element for now, to make it possible for Jest to render DOM nodes.
@@ -32,5 +35,12 @@ describe("Index", () => {
         }
 
         domStream.end();
+    });
+
+    describe("API", () => {
+        it("should export the appropriate APIs", () => {
+            expect(RssHandler).toEqual(FeedHandler);
+            expect(DomHandler).toEqual(DefaultHandler);
+        });
     });
 });


### PR DESCRIPTION
Some improvements for (else branch) coverage, bringing two files up to full 100% coverage. Also fixes a linting warning.

- feedhandler: overcome lint warning
- test(WritableStream): cover else branch
- test(Parser): cover (open-implies-close case of) `onclosetag` else branch with non-`br` void close tag in non-XML mode
- refactor: improve else coverage by avoiding `openImpliesClose` optional chaining operator (check for existence already made upon entering block)
- refactor: improve coverage by avoiding null check for `endIndex` (since by calling `_updatePosition`, it will never be `null`). Cast endIndex as number to avoid TS believing it could be null.
