### PR TITLE
Export Callbacks interface

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -104,7 +104,7 @@ function isASCIIAlpha(c: string): boolean {
     return (c >= "a" && c <= "z") || (c >= "A" && c <= "Z");
 }
 
-interface Callbacks {
+export interface Callbacks {
     onattribdata(value: string): void;
     onattribend(quote: string | undefined | null): void;
     onattribname(name: string): void;


### PR DESCRIPTION
Callbacks interface is used in Tokenizer constructor, but was not exported.