### PR TITLE
Parses ERB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 lib/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -122,6 +122,42 @@ const feed = htmlparser2.parseFeed(content, options);
 Note: While the provided feed handler works for most feeds,
 you might want to use [danmactough/node-feedparser](https://github.com/danmactough/node-feedparser), which is much better tested and actively maintained.
 
+## Parsing ERB
+
+```javascript
+const htmlparser2 = require("htmlparser2");
+const parser = new htmlparser2.Parser({
+    onerbscriptlet(data) {
+        /*
+         * This fires when an ERB scriptlet ends.
+         *
+         */
+        console.log("Scriptlet:", data);
+    },
+    onerbexpression(data) {
+        /*
+         * This fires when an ERB expression ends.
+         *
+         */
+        console.log("Expression:", data);
+    },
+});
+parser.write(
+    "<% arr.each do |elem| %>\n"
+    "   <%= elem %>\n"
+    "<% end %>"
+);
+parser.end();
+```
+
+Output:
+
+```
+Scriptlet: arr.each do |elem|
+Expression: elem
+Scriptlet: end
+```
+
 ## Performance
 
 After having some artificial benchmarks for some time, **@AndreasMadsen** published his [`htmlparser-benchmark`](https://github.com/AndreasMadsen/htmlparser-benchmark), which benchmarks HTML parses based on real-world websites.

--- a/src/MultiplexHandler.ts
+++ b/src/MultiplexHandler.ts
@@ -48,6 +48,12 @@ export default class MultiplexHandler implements Handler {
     onopentagname(name: string): void {
         this.func("onopentagname", name);
     }
+    onerbexpression(data: string): void {
+        this.func("onerbexpression", data);
+    }
+    onerbscriptlet(data: string): void {
+        this.func("onerbscriptlet", data);
+    }
     onerror(error: Error): void {
         this.func("onerror", error);
     }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -185,6 +185,8 @@ export interface Handler {
     oncdataend(): void;
     oncommentend(): void;
     onprocessinginstruction(name: string, data: string): void;
+    onerbexpression(data: string): void;
+    onerbscriptlet(data: string): void;
 }
 
 const reNameEnd = /\s|\//;
@@ -421,6 +423,16 @@ export class Parser {
             );
         }
         this.cbs.onend?.();
+    }
+
+    onerbexpression(data: string): void {
+        this.updatePosition(3);
+        this.cbs.onerbexpression?.(data);
+    }
+
+    onerbscriptlet(data: string): void {
+        this.updatePosition(2);
+        this.cbs.onerbscriptlet?.(data);
     }
 
     /**

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -407,7 +407,7 @@ export default class Tokenizer {
     private stateAfterErbExpressionPercent(c: string) {
         if (c === ">") {
             this._state = State.Text;
-            this.cbs.onerbexpression(this.getSection());
+            this.cbs.onerbexpression(this.getSection().substring(1, this.getSection().length - 1));
         } else {
             // False alarm - re-read as ERB
             this._state = State.InErbExpression;
@@ -417,7 +417,7 @@ export default class Tokenizer {
     private stateAfterErbScriptletPercent(c: string) {
         if (c === ">") {
             this._state = State.Text;
-            this.cbs.onerbscriptlet(this.getSection());
+            this.cbs.onerbscriptlet(this.getSection().substring(1, this.getSection().length - 1));
         } else {
             // False alarm - re-read as ERB
             this._state = State.InErbScriptlet;

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -124,8 +124,8 @@ export interface Callbacks {
     onprocessinginstruction(instruction: string): void;
     onselfclosingtag(): void;
     ontext(value: string): void;
-    onerbexpression(value: string): void;
-    onerbscriptlet(value: string): void;
+    onerbexpression(): void;
+    onerbscriptlet(): void;
 }
 
 function ifElseState(upper: string, SUCCESS: State, FAILURE: State) {
@@ -387,10 +387,12 @@ export default class Tokenizer {
     }
     private stateBeforeErbPercent(c: string) {
         if (c === "=") {
+            this.cbs.onerbexpression();
             this._state = State.Text;
             this.special = Special.ErbExpression;
             this.sectionStart = this._index;
         } else {
+            this.cbs.onerbscriptlet();
             this._state = State.Text;
             this.special = Special.ErbScriptlet;
             this.sectionStart = this._index;
@@ -408,7 +410,6 @@ export default class Tokenizer {
     private stateAfterErbPercent(c: string) {
         if (c === ">") {
             this._state = State.Text;
-            this.emitToken(this.special === Special.ErbExpression ? "onerbexpression" : "onerbscriptlet");
             this.special = Special.None;
         } else {
             // False alarm
@@ -1015,7 +1016,7 @@ export default class Tokenizer {
     private getSection(): string {
         return this.buffer.substring(this.sectionStart, this._index);
     }
-    private emitToken(name: "onopentagname" | "onclosetag" | "onattribdata" | "onerbexpression" | "onerbscriptlet") {
+    private emitToken(name: "onopentagname" | "onclosetag" | "onattribdata") {
         this.cbs[name](this.getSection());
         this.sectionStart = -1;
     }


### PR DESCRIPTION
For the purposes of a project I'm working on, I've put together a wee extension to htmlparser2 to do basic ERB parsing. ERB scriptlets and expressions are parsed in much the same way that comments are currently. The Tokenizer passes through a series of ERB-specific states, finally passing the body of the ERB tag via two callbacks, `onerbexpression` and `onerbscriptlet` when the ERB tag closes.

![HTMLParser2 Tokenizer ERB Flowchart](https://user-images.githubusercontent.com/85557754/123233578-137b4b00-d4d2-11eb-9cb8-164b6775f6cc.jpg)

The only logical flaw in this design is that it is technically possible for `%>` to occur within a quoted string within ERB code without closing the ERB tag, e.g. `<%= "Hello %> world!" %>`. As it stands, my design will think that `"Hello` is the whole content of an ERB tag and read `world!" %>` as plain text, which is of course not ideal behaviour. However, this seems to be a fairly rare edge case, and, given the myriad ways of quoting strings in Ruby, it would be a reasonable amount of work to account for it, so I've left it for the time being.

I don't know if this is something you would be interested in having merged - if this would just bloat your package, reject this PR, I won't be offended ;) I just thought it would be a shame not to let you know in case you did like the look of it.