### PR TITLE
Erb blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 lib/
+.vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1211,9 +1211,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "15.12.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+            "version": "15.12.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.3.tgz",
+            "integrity": "sha512-SNt65CPCXvGNDZ3bvk1TQ0Qxoe3y1RKH88+wZ2Uf05dduBCqqFQ76ADP9pbT+Cpvj60SkRppMCh2Zo8tDixqjQ==",
             "dev": true
         },
         "node_modules/@types/prettier": {
@@ -7270,9 +7270,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "15.12.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+            "version": "15.12.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.3.tgz",
+            "integrity": "sha512-SNt65CPCXvGNDZ3bvk1TQ0Qxoe3y1RKH88+wZ2Uf05dduBCqqFQ76ADP9pbT+Cpvj60SkRppMCh2Zo8tDixqjQ==",
             "dev": true
         },
         "@types/prettier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5981,9 +5981,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+            "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -10966,9 +10966,9 @@
             }
         },
         "typescript": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+            "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
             "dev": true
         },
         "universalify": {

--- a/src/MultiplexHandler.ts
+++ b/src/MultiplexHandler.ts
@@ -48,6 +48,12 @@ export default class MultiplexHandler implements Handler {
     onopentagname(name: string): void {
         this.func("onopentagname", name);
     }
+    onerbexpression(data: string): void {
+        this.func("onerbexpression", data);
+    }
+    onerbscriptlet(data: string): void {
+        this.func("onerbscriptlet", data);
+    }
     onerror(error: Error): void {
         this.func("onerror", error);
     }

--- a/src/MultiplexHandler.ts
+++ b/src/MultiplexHandler.ts
@@ -1,4 +1,5 @@
 import type { Parser, Handler } from "./Parser";
+import { ErbBeginBlock, ErbEndBlock } from "./Tokenizer";
 
 /**
  * Calls a specific handler function for all events that are encountered.
@@ -53,6 +54,12 @@ export default class MultiplexHandler implements Handler {
     }
     onerbscriptlet(data: string): void {
         this.func("onerbscriptlet", data);
+    }
+    onerbbeginblock(beginBlock: ErbBeginBlock): void {
+        this.func("onerbbeginblock", beginBlock);
+    }
+    onerbendblock(endBlock: ErbEndBlock): void {
+        this.func("onerbendblock", endBlock);
     }
     onerror(error: Error): void {
         this.func("onerror", error);

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -185,6 +185,8 @@ export interface Handler {
     oncdataend(): void;
     oncommentend(): void;
     onprocessinginstruction(name: string, data: string): void;
+    onerbexpression(data: string): void;
+    onerbscriptlet(data: string): void;
 }
 
 const reNameEnd = /\s|\//;
@@ -421,6 +423,16 @@ export class Parser {
             );
         }
         this.cbs.onend?.();
+    }
+
+    onerbexpression(data: string): void {
+        this.updatePosition(3);
+        this.cbs.onerbexpression?.(data);
+    }
+
+    onerbscriptlet(data: string): void {
+        this.updatePosition(2);
+        this.cbs.onerbscriptlet?.(data);
     }
 
     /**

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,4 +1,4 @@
-import Tokenizer from "./Tokenizer";
+import Tokenizer, { ErbBeginBlock, ErbEndBlock } from "./Tokenizer";
 
 const formTags = new Set([
     "input",
@@ -187,6 +187,8 @@ export interface Handler {
     onprocessinginstruction(name: string, data: string): void;
     onerbexpression(data: string): void;
     onerbscriptlet(data: string): void;
+    onerbbeginblock(beginBlock: ErbBeginBlock): void;
+    onerbendblock(endBlock: ErbEndBlock): void;
 }
 
 const reNameEnd = /\s|\//;
@@ -426,13 +428,19 @@ export class Parser {
     }
 
     onerbexpression(data: string): void {
-        this.updatePosition(3);
         this.cbs.onerbexpression?.(data);
     }
 
     onerbscriptlet(data: string): void {
-        this.updatePosition(2);
         this.cbs.onerbscriptlet?.(data);
+    }
+
+    onerbbeginblock(beginBlock: ErbBeginBlock): void {
+        this.cbs.onerbbeginblock?.(beginBlock);
+    }
+
+    onerbendblock(endBlock: ErbEndBlock): void {
+        this.cbs.onerbendblock?.(endBlock);
     }
 
     /**

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -459,14 +459,14 @@ export default class Tokenizer {
         regexpResult = /^\s*unless (.*) then\s*$/m.exec(body);
         if (!regexpResult) regexpResult = /^\s*unless (.*)$/m.exec(body);
         if (regexpResult) {
-            return new ErbBeginBlock("unless", { condition: regexpResult[1] });
+            return new ErbBeginBlock("unless", { condition: regexpResult[1].trim() });
         }
 
         // Loop (for)
         regexpResult = /^\s*for (.*) in (.*) do\s*$/m.exec(body);
         if (!regexpResult) regexpResult = /^\s*for (.*) in (.*)\s*$/m.exec(body);
         if (regexpResult) {
-            return new ErbBeginBlock("for", { variable: regexpResult[1], iterable: regexpResult[2] });
+            return new ErbBeginBlock("for", { variable: regexpResult[1].trim(), iterable: regexpResult[2].trim() });
         }
         
         // Conditional (else)
@@ -479,14 +479,14 @@ export default class Tokenizer {
         regexpResult = /^\s*elsif (.*) then\s*$/m.exec(body);
         if (!regexpResult) regexpResult = /^\s*elsif (.*)$/m.exec(body);
         if (regexpResult) {
-            return new ErbBeginBlock("elsif", { condition: regexpResult[1] });
+            return new ErbBeginBlock("elsif", { condition: regexpResult[1].trim() });
         }
 
         // Loop (until)
         regexpResult = /^\s*until (.*) do\s*$/m.exec(body);
         if (!regexpResult) regexpResult = /^\s*until (.*)\s*$/m.exec(body);
         if (regexpResult) {
-            return new ErbBeginBlock("until", { condition: regexpResult[1] });
+            return new ErbBeginBlock("until", { condition: regexpResult[1].trim() });
         }
 
         // Begin

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -462,7 +462,12 @@ export default class Tokenizer {
             return new ErbBeginBlock("unless", { condition: regexpResult[1] });
         }
 
-        // TODO: Loop (for)
+        // Loop (for)
+        regexpResult = /^\s*for (.*) in (.*) do\s*$/m.exec(body);
+        if (!regexpResult) regexpResult = /^\s*for (.*) in (.*)\s*$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("for", { variable: regexpResult[1], iterable: regexpResult[2] });
+        }
         
         // TODO: Conditional (elsif)
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -131,14 +131,20 @@ export interface Callbacks {
     onerbendblock(endBlock: ErbEndBlock): void;
 }
 
-export type ErbBlockKeyword = "if" | "unless" | "while" | "until" | "for" | "begin";
+export type ErbBlockKeyword = "if" | "unless" | "while" | "until" | "for" | "begin" | "do";
+export type ErbConditionalBlockData = Required<{ condition: string, }>;
+export type ErbForBlockData = Required<{ variable: string, iterable: string, }>;
+export type ErbDoBlockData = Required<{ func: string, params: string[], }>;
+export type ErbEmptyBlockData = null;
+export type ErbBlockData = ErbConditionalBlockData | ErbForBlockData | ErbDoBlockData | ErbEmptyBlockData;
 
 export class ErbBeginBlock {
     public readonly keyword: ErbBlockKeyword;
-    public readonly expression: string | undefined;
-    constructor(keyword: ErbBlockKeyword, expression?: string) {
+    public readonly data: ErbBlockData;
+    constructor(keyword: ErbBlockKeyword, data: ErbBlockData) {
         this.keyword = keyword;
-        this.expression = expression;
+        this.data = data;
+		// TODO: check data is a suitable type given the keyword supplied.
     }
 };
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -445,7 +445,10 @@ export default class Tokenizer {
 		regexpResult = /^\s*([^\s]+) do \|(.*)\|\s*$/m.exec(body);
 		if (!regexpResult) regexpResult = /^\s*([^\s]+) do\s*$/m.exec(body);
 		if (regexpResult) {
-			return new ErbBeginBlock("do", { func: regexpResult[1], params: regexpResult[2] ? regexpResult[2].split(", ") : [], } );
+			return new ErbBeginBlock("do", {
+				func: regexpResult[1],
+				params: regexpResult[2] ? regexpResult[2].split(",").map(str => str.trim()) : [],
+			});
 		}
 
         // TODO: Conditional (unless)

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -408,19 +408,19 @@ export default class Tokenizer {
     }
     private stateInErbExpression(c: string) {
         if (c === "%") {
-            // If %> occurs in the middle of a "string", this will
-            // be parsed as the end of the ERB even though it isn't.
-            // A fairly unlikely edge case, but should probably sort
-            // out it sooner or later...
+            /* If %> occurs in the middle of a "string", this will
+             * be parsed as the end of the ERB even though it isn't.
+             * A fairly unlikely edge case, but should probably sort
+             * out it sooner or later... */
             this._state = State.AfterErbExpressionPercent;
         }
     }
     private stateInErbScriptlet(c: string) {
         if (c === "%") {
-            // If %> occurs in the middle of a "string", this will
-            // be parsed as the end of the ERB even though it isn't.
-            // A fairly unlikely edge case, but should probably sort
-            // out it sooner or later...
+            /* If %> occurs in the middle of a "string", this will
+             * be parsed as the end of the ERB even though it isn't.
+             * A fairly unlikely edge case, but should probably sort
+             * out it sooner or later... */
             this._state = State.AfterErbScriptletPercent;
         }
     }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -407,7 +407,7 @@ export default class Tokenizer {
     private stateAfterErbExpressionPercent(c: string) {
         if (c === ">") {
             this._state = State.Text;
-            this.cbs.onerbexpression(this.getSection());
+            this.cbs.onerbexpression(this.getSection().substring(1, this.getSection().length - 1));
         } else {
             // False alarm - re-read as ERB
             this._state = State.InErbExpression;
@@ -417,7 +417,7 @@ export default class Tokenizer {
     private stateAfterErbScriptletPercent(c: string) {
         if (c === ">") {
             this._state = State.Text;
-            this.cbs.onerbscriptlet(this.getSection());
+            this.cbs.onerbscriptlet(this.getSection().substring(1, this.getSection().length - 1));
         } else {
             // False alarm - re-read as ERB
             this._state = State.InErbScriptlet;

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -515,7 +515,11 @@ export default class Tokenizer {
             return new ErbBeginBlock("when", { matches: regexpResult[1].split(",").map(str => str.trim()) });
         }
 
-        // TODO: Loop (while)
+        // Loop (while)
+        regexpResult = /^\s*while (.*)\s*$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("while", { condition: regexpResult[1].trim() });
+        }
 
         return null;
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -455,7 +455,12 @@ export default class Tokenizer {
 			});
 		}
 
-        // TODO: Conditional (unless)
+        // Conditional (unless)
+        regexpResult = /^\s*unless (.*) then\s*$/m.exec(body);
+        if (!regexpResult) regexpResult = /^\s*unless (.*)$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("unless", { condition: regexpResult[1] });
+        }
 
         // TODO: Loop (for)
         

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -469,7 +469,18 @@ export default class Tokenizer {
             return new ErbBeginBlock("for", { variable: regexpResult[1], iterable: regexpResult[2] });
         }
         
-        // TODO: Conditional (elsif)
+        // Conditional (else)
+        regexpResult = /^\s*else\s*$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("else", null);
+        }
+
+        // Conditional (elsif)
+        regexpResult = /^\s*elsif (.*) then\s*$/m.exec(body);
+        if (!regexpResult) regexpResult = /^\s*elsif (.*)$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("elsif", { condition: regexpResult[1] });
+        }
 
         // TODO: Loop (until)
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -490,7 +490,7 @@ export default class Tokenizer {
     private stateAfterErbPercentAgnostic(c: string, erbType: "expression" | "scriptlet") {
         if (c === ">") {
             this._state = State.Text;
-            const body = this.getSection().substring(1, this.getSection().length - 1);
+            const body = this.getSection().substring(1, this.getSection().length - 1).trim();
             const beginBlock = this.getErbBeginBlock(body);
 			const endBlock = this.getErbEndBlock(body);
             if (beginBlock)

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -489,7 +489,11 @@ export default class Tokenizer {
             return new ErbBeginBlock("until", { condition: regexpResult[1] });
         }
 
-        // TODO: Begin
+        // Begin
+        regexpResult = /^\s*begin\s*$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("begin", null);
+        }
 
         // TODO: Case
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -414,19 +414,23 @@ export default class Tokenizer {
     }
     private stateInErbExpression(c: string) {
         if (c === "%") {
-            /* If %> occurs in the middle of a "string", this will
+            /**
+             * If %> occurs in the middle of a "string", this will
              * be parsed as the end of the ERB even though it isn't.
              * A fairly unlikely edge case, but should probably sort
-             * out it sooner or later... */
+             * out it sooner or later...
+             */
             this._state = State.AfterErbExpressionPercent;
         }
     }
     private stateInErbScriptlet(c: string) {
         if (c === "%") {
-            /* If %> occurs in the middle of a "string", this will
+            /**
+             * If %> occurs in the middle of a "string", this will
              * be parsed as the end of the ERB even though it isn't.
              * A fairly unlikely edge case, but should probably sort
-             * out it sooner or later... */
+             * out it sooner or later...
+             */
             this._state = State.AfterErbScriptletPercent;
         }
     }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -135,8 +135,10 @@ export type ErbBlockKeyword = "if" | "unless" | "else" | "elsif" | "case" | "whe
 export type ErbConditionalBlockData = Required<{ condition: string, }>;
 export type ErbForBlockData = Required<{ variable: string, iterable: string, }>;
 export type ErbDoBlockData = Required<{ func: string, params: string[], }>;
+export type ErbCaseBlockData = Required<{ expression: string }>;
+export type ErbWhenBlockData = Required<{ matches: string[] }>;
 export type ErbEmptyBlockData = null;
-export type ErbBlockData = ErbConditionalBlockData | ErbForBlockData | ErbDoBlockData | ErbEmptyBlockData;
+export type ErbBlockData = ErbConditionalBlockData | ErbForBlockData | ErbDoBlockData | ErbCaseBlockData | ErbWhenBlockData | ErbEmptyBlockData;
 
 export class ErbBeginBlock {
     public readonly keyword: ErbBlockKeyword;
@@ -495,7 +497,23 @@ export default class Tokenizer {
             return new ErbBeginBlock("begin", null);
         }
 
-        // TODO: Case
+        // Case [expression]
+        regexpResult = /^\s*case (.*)\s*$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("case", { expression: regexpResult[1].trim() });
+        }
+
+        // Case
+        regexpResult = /^\s*case\s*$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("case", null);
+        }
+
+        // When
+        regexpResult = /^\s*when (.*)\s*$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("when", { matches: regexpResult[1].split(",").map(str => str.trim()) });
+        }
 
         // TODO: Loop (while)
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -124,8 +124,8 @@ export interface Callbacks {
     onprocessinginstruction(instruction: string): void;
     onselfclosingtag(): void;
     ontext(value: string): void;
-    onerbexpression(value: string): void;
-    onerbscriptlet(value: string): void;
+    onerbexpression(): void;
+    onerbscriptlet(): void;
 }
 
 function ifElseState(upper: string, SUCCESS: State, FAILURE: State) {
@@ -387,10 +387,12 @@ export default class Tokenizer {
     }
     private stateBeforeErbPercent(c: string) {
         if (c === "=") {
+            this.cbs.onerbexpression();
             this._state = State.Text;
             this.special = Special.ErbExpression;
             this.sectionStart = this._index;
         } else {
+            this.cbs.onerbscriptlet();
             this._state = State.Text;
             this.special = Special.ErbScriptlet;
             this.sectionStart = this._index;
@@ -408,7 +410,6 @@ export default class Tokenizer {
     private stateAfterErbPercent(c: string) {
         if (c === ">") {
             this._state = State.Text;
-            this.emitToken(this.special === Special.ErbExpression ? "onerbexpression" : "onerbscriptlet");
             this.special = Special.None;
         } else {
             // False alarm
@@ -1015,7 +1016,7 @@ export default class Tokenizer {
     private getSection(): string {
         return this.buffer.substring(this.sectionStart, this._index);
     }
-    private emitToken(name: "onopentagname" | "onclosetag" | "onattribdata" | "onerbexpression" | "onerbscriptlet") {
+    private emitToken(name: "onopentagname" | "onclosetag" | "onattribdata") {
         this.cbs[name](this.getSection());
         this.sectionStart = -1;
     }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -461,12 +461,12 @@ export default class Tokenizer {
         if (c === ">") {
             this._state = State.Text;
             const body = this.getSection().substring(1, this.getSection().length - 1);
-            const beginBlock = this.getErbBeginBlock(body), endBlock;
+            const beginBlock = this.getErbBeginBlock(body);
+			const endBlock = this.getErbEndBlock(body);
             if (beginBlock)
                 this.cbs.onerbbeginblock(beginBlock);
-            else if (endBlock = this.getErbEndBlock(body)) {
+            else if (endBlock)
                 this.cbs.onerbendblock(endBlock);
-            }
             else
                 this.cbs[erbType === "expression" ? "onerbexpression" : "onerbscriptlet"](body);
         } else {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -131,7 +131,7 @@ export interface Callbacks {
     onerbendblock(endBlock: ErbEndBlock): void;
 }
 
-export type ErbBlockKeyword = "if" | "unless" | "while" | "until" | "for" | "begin" | "do";
+export type ErbBlockKeyword = "if" | "unless" | "else" | "elsif" | "case" | "when" | "while" | "until" | "for" | "begin" | "do";
 export type ErbConditionalBlockData = Required<{ condition: string, }>;
 export type ErbForBlockData = Required<{ variable: string, iterable: string, }>;
 export type ErbDoBlockData = Required<{ func: string, params: string[], }>;

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -489,7 +489,7 @@ export default class Tokenizer {
                 this.cbs[erbType === "expression" ? "onerbexpression" : "onerbscriptlet"](body);
         } else {
             // False alarm - re-read as ERB
-            this._state = State.InErbScriptlet;
+            this._state = erbType === "expression" ? State.InErbExpression : State.InErbScriptlet;
             this._index--;
         }
     }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -482,7 +482,12 @@ export default class Tokenizer {
             return new ErbBeginBlock("elsif", { condition: regexpResult[1] });
         }
 
-        // TODO: Loop (until)
+        // Loop (until)
+        regexpResult = /^\s*until (.*) do\s*$/m.exec(body);
+        if (!regexpResult) regexpResult = /^\s*until (.*)\s*$/m.exec(body);
+        if (regexpResult) {
+            return new ErbBeginBlock("until", { condition: regexpResult[1] });
+        }
 
         // TODO: Begin
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -465,6 +465,8 @@ export default class Tokenizer {
 
         // TODO: Begin
 
+        // TODO: Case
+
         // TODO: Loop (while)
 
         return null;

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -461,8 +461,8 @@ export default class Tokenizer {
     private stateAfterErbPercentAgnostic(c: string, erbType: "expression" | "scriptlet") {
         if (c === ">") {
             this._state = State.Text;
-            let body = this.getSection().substring(1, this.getSection().length - 1);
-            let beginBlock = this.getErbBeginBlock(body), endBlock;
+            const body = this.getSection().substring(1, this.getSection().length - 1);
+            const beginBlock = this.getErbBeginBlock(body), endBlock;
             if (beginBlock)
                 this.cbs.onerbbeginblock(beginBlock);
             else if (endBlock = this.getErbEndBlock(body)) {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -428,27 +428,26 @@ export default class Tokenizer {
 
         let regexpResult;
 
-        // if [condition] then
+        // Conditional (if)
         regexpResult = /^\s*if (.*) then\s*$/m.exec(body);
-        // if [condition]
         if (!regexpResult) regexpResult = /^\s*if (.*)$/.exec(body);
         if (regexpResult) {
             return new ErbBeginBlock("if", regexpResult[1]);
         }
 
-        // method call block e.g. "list.each do |elem|"" or "render(...) do"
+        // TODO: Method call block e.g. "list.each do |elem|"" or "render(...) do"
 
-        // unless
+        // TODO: Conditional (unless)
 
-        // for
+        // TODO: Loop (for)
         
-        // elsif
+        // TODO: Conditional (elsif)
 
-        // until
+        // TODO: Loop (until)
 
-        // begin
+        // TODO: Begin
 
-        // while
+        // TODO: Loop (while)
 
         return null;
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -436,12 +436,17 @@ export default class Tokenizer {
 
         // Conditional (if)
         regexpResult = /^\s*if (.*) then\s*$/m.exec(body);
-        if (!regexpResult) regexpResult = /^\s*if (.*)$/.exec(body);
+        if (!regexpResult) regexpResult = /^\s*if (.*)$/m.exec(body);
         if (regexpResult) {
-            return new ErbBeginBlock("if", regexpResult[1]);
+            return new ErbBeginBlock("if", { condition: regexpResult[1] });
         }
 
-        // TODO: Method call block e.g. "list.each do |elem|"" or "render(...) do"
+        // Method call block e.g. "list.each do |elem|"" or "render(...) do"
+		regexpResult = /^\s*([^\s]+) do \|(.*)\|\s*$/m.exec(body);
+		if (!regexpResult) regexpResult = /^\s*([^\s]+) do\s*$/m.exec(body);
+		if (regexpResult) {
+			return new ErbBeginBlock("do", { func: regexpResult[1], params: regexpResult[2] ? regexpResult[2].split(", ") : [], } );
+		}
 
         // TODO: Conditional (unless)
 


### PR DESCRIPTION
Parses when an ERB "block" (in a loose sense, encompassing loops, conditionals, etc - basically, anything that concludes with the "end" keyword) begins and ends.

There's still a significant remaining problem with the current approach: it assumes that the ERB code block only contains one line of code.