### PR TITLE
fix(parser): Index of closing tag was misaligned

### DIFF
--- a/src/Parser.spec.ts
+++ b/src/Parser.spec.ts
@@ -89,10 +89,20 @@ describe("API", () => {
         expect(p.startIndex).toBe(0);
         expect(p.endIndex).toBe(2);
 
-        p.write("<bar>");
+        p.write("<select>");
 
         expect(p.startIndex).toBe(3);
-        expect(p.endIndex).toBe(7);
+        expect(p.endIndex).toBe(10);
+
+        p.write("<select>");
+
+        expect(p.startIndex).toBe(11);
+        expect(p.endIndex).toBe(18);
+
+        p.parseChunk("</select>");
+
+        expect(p.startIndex).toBe(19);
+        expect(p.endIndex).toBe(27);
     });
 
     test("should not have the start index be greater than the end index", () => {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -286,7 +286,7 @@ export class Parser {
     }
 
     onclosetag(name: string): void {
-        this.updatePosition(1);
+        this.updatePosition(2);
         if (this.lowerCaseTagNames) {
             name = name.toLowerCase();
         }


### PR DESCRIPTION
Reported by @thewilkybarkid in https://github.com/posthtml/posthtml-parser/pull/80#issuecomment-903320512