### PR TITLE
refactor(tokenizer): Remove unused branches, improve test coverage

### DIFF
--- a/src/__fixtures__/Events/37-entity-in-title.json
+++ b/src/__fixtures__/Events/37-entity-in-title.json
@@ -1,6 +1,6 @@
 {
     "name": "entity in title (#592)",
-    "html": "<title>the &quot;title&quot;",
+    "html": "<title>the &quot;title&quot",
     "expected": [
         {
             "event": "opentagname",

--- a/src/__fixtures__/Events/41-trailing-legacy-entity.json
+++ b/src/__fixtures__/Events/41-trailing-legacy-entity.json
@@ -1,0 +1,10 @@
+{
+    "name": "Trailing legacy entity",
+    "html": "&timesbar;&timesbar",
+    "expected": [
+        {
+            "data": ["⨱×bar"],
+            "event": "text"
+        }
+    ]
+}

--- a/src/__fixtures__/Events/42-trailing-numeric-entity.json
+++ b/src/__fixtures__/Events/42-trailing-numeric-entity.json
@@ -1,0 +1,10 @@
+{
+    "name": "Trailing numeric entity",
+    "html": "&#53&#53",
+    "expected": [
+        {
+            "data": ["55"],
+            "event": "text"
+        }
+    ]
+}


### PR DESCRIPTION
Changes relevant for people extending `Tokenizer`: `Tokenizer`'s `option` argument can no longer be `null`, and we no longer check for unknown states.