### PR TITLE
Test additions to expose/clarify perviously uncovered distinctions between "self closing tags" and void elements

### DIFF
--- a/src/__fixtures__/Events/07b-self-closing.json
+++ b/src/__fixtures__/Events/07b-self-closing.json
@@ -1,6 +1,11 @@
 {
-    "name": "Self-closing tags",
+    "name": "Self-closing tags (recognizeSelfClosing=true)",
     "input": "<a href=http://test.com/>Foo</a><hr / ><break /><br/><img src='w3html.gif'/>",
+    "options": {
+        "parser": {
+            "recognizeSelfClosing": true
+        }
+    },
     "expected": [
         {
             "event": "opentagname",
@@ -69,6 +74,12 @@
             "data": ["break", {}, false]
         },
         {
+            "event": "closetag",
+            "startIndex": 39,
+            "endIndex": 47,
+            "data": ["break", true]
+        },
+        {
             "event": "opentagname",
             "startIndex": 48,
             "endIndex": 51,
@@ -115,12 +126,6 @@
             "startIndex": 53,
             "endIndex": 75,
             "data": ["img", true]
-        },
-        {
-            "event": "closetag",
-            "startIndex": 76,
-            "endIndex": 76,
-            "data": ["break", true]
         }
     ]
 }

--- a/src/__fixtures__/Events/35-non-br-void-close-tag.json
+++ b/src/__fixtures__/Events/35-non-br-void-close-tag.json
@@ -1,6 +1,6 @@
 {
     "name": "open-implies-close case of (non-br) void close tag in non-XML mode",
-    "input": "<select><input></select>",
+    "input": "<select><input><br></select>",
     "options": {
         "parser": {
             "lowerCaseAttributeNames": true
@@ -42,6 +42,24 @@
             "startIndex": 8,
             "endIndex": 14,
             "data": ["input", true]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 15,
+            "endIndex": 18,
+            "data": ["br"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 15,
+            "endIndex": 18,
+            "data": ["br", {}, false]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 15,
+            "endIndex": 18,
+            "data": ["br", true]
         }
     ]
 }


### PR DESCRIPTION
This PR is first a forum for clarification, using test code for demonstration. Whether or not all or part of the test code changes should be accepted, modified or refactored depends on the outcome of this clarification.

The issue covered are:

- distinction between "self closing tags" and "void elements"

  The parser makes this distinction implicitly. I was able to piece this together from comments made in previous Issues/Pull Requests (where such a distinction is asserted) many years ago, from the code, and from the existence of the `recognizeSelfClosing` option. But there is no documentation on this distinction, even though void elements employ self closing tags. Either these terms should be synonymous or void elements is a subset of self closing tags.

  It's unclear whether this distinction makes sense.  Or whether it makes sense that in HTML mode the self-closing `/>` tag pattern is ignored and an `onclosetag` event is generated later in the event stream no where near the actual self-closing tag.

- The meaning and intent of the `recognizeSelfClosing` option.

  This option was introduced in https://github.com/fb55/htmlparser2/pull/74 but without any tests nor any documentation. 

  > To confirm there is no test coverage:
  >
  > 1. Temporarily add the following line to `Parser.ts`'s constructor:
  >
  >    ```
  >    this.options.recognizeSelfClosing = !this.options.recognizeSelfClosing
  >    ```
  >
  >    This will invert this option for every test, which will cause any test covering this option to fail.
  >
  > 2. Run the tests. **No tests will fail.**

  Some documentation has been added since, but the distinction between "self closing tags" and "void elements" is still unclear, as is the real meaning of `recognizeSelfClosing`.

- `Parser.ts` has [special logic for `<br>`](https://github.com/fb55/htmlparser2/blob/6445c32b05dc070049eeaaf201bfc123daca3d37/src/Parser.ts#L340) vs other void elements.

  But it's hard to figure out what the effective difference is. 

- The lack of tests covering/documenting the above.



The following test changes were made. All the tests PASS, so actual behavior is demonstrated.  Questions raised are flagged with 🌶.

- `07-self-closing.json` has extended input:

  - Both "self-closing tags" and "void elements" to expose behavioral differences. Compare the different results for `<hr />` (void element) and `<break />` (self-closing tag). 

    > 🌶 clearly there is a difference. Is what the test shows intentional?

  - The addition of `<br />`  to expose any different treatment or lack thereof.

    > 🌶 no apparent difference. (see also test 35 below)

  - A void element with attributes to add coverage of that scenario.

    Seems a-ok.

-  `07b-self-closing.json` was added. It has the exact same input as `07-self-closing.json`, but the Parser's`recognizeSelfClosing` is set to true.

    > 🌶 Diff `07` and `07a` to see the differences. 
    >
    > Is the point of the `recognizeSelfClosing` option to allow self-closing tags that are not standard HTML "void elements" to be supported? i.e. does it exist to address #1015 but without having to enable all the other parts of `xmlMode`?

- `35-non-br-void-close-tag.json` has extended input: `<br>` was added to show whether `<br>` in fact has different treatment as the name of the test implies.  

  > 🌶 The test exposed no differences. The events for `<br>` are identical to `<input>`. Then what exactly does [this special logic](https://github.com/fb55/htmlparser2/blob/6445c32b05dc070049eeaaf201bfc123daca3d37/src/Parser.ts#L340) do?



Happy to make any changes or refactors to these tests. 

