### PR TITLE
refactor: Don't concatenate strings

### DIFF
--- a/src/Parser.spec.ts
+++ b/src/Parser.spec.ts
@@ -48,11 +48,11 @@ describe("API", () => {
         p.resume();
         expect(onText).toHaveBeenCalledTimes(1);
         p.pause();
-        p.end("foo");
+        p.end("bar");
         expect(onText).toHaveBeenCalledTimes(1);
         p.resume();
         expect(onText).toHaveBeenCalledTimes(2);
-        expect(onText).toHaveBeenLastCalledWith("foo");
+        expect(onText).toHaveBeenLastCalledWith("bar");
     });
 
     test("should back out of numeric entities (#125)", () => {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -257,10 +257,10 @@ export class Parser implements Callbacks {
     }
 
     /** @internal */
-    onopentagname(start: number, length: number): void {
-        this.endIndex = this.tokenizer.getIndex();
+    onopentagname(start: number, endIndex: number): void {
+        this.endIndex = endIndex;
 
-        let name = this.getSubstr(start, length);
+        let name = this.getSubstr(start, endIndex - start);
 
         if (this.lowerCaseTagNames) {
             name = name.toLowerCase();
@@ -321,10 +321,10 @@ export class Parser implements Callbacks {
     }
 
     /** @internal */
-    onclosetag(start: number, length: number): void {
-        this.endIndex = this.tokenizer.getIndex();
+    onclosetag(start: number, endIndex: number): void {
+        this.endIndex = endIndex;
 
-        let name = this.getSubstr(start, length);
+        let name = this.getSubstr(start, endIndex - start);
 
         if (this.lowerCaseTagNames) {
             name = name.toLowerCase();
@@ -412,8 +412,8 @@ export class Parser implements Callbacks {
     }
 
     /** @internal */
-    onattribend(quote: QuoteType): void {
-        this.endIndex = this.tokenizer.getIndex();
+    onattribend(quote: QuoteType, endIndex: number): void {
+        this.endIndex = endIndex;
 
         const quoteVal =
             quote === QuoteType.Double
@@ -447,9 +447,9 @@ export class Parser implements Callbacks {
     }
 
     /** @internal */
-    ondeclaration(start: number, length: number): void {
-        this.endIndex = this.tokenizer.getIndex();
-        const value = this.getSubstr(start, length);
+    ondeclaration(start: number, endIndex: number): void {
+        this.endIndex = endIndex;
+        const value = this.getSubstr(start, endIndex - start);
 
         if (this.cbs.onprocessinginstruction) {
             const name = this.getInstructionName(value);
@@ -461,9 +461,9 @@ export class Parser implements Callbacks {
     }
 
     /** @internal */
-    onprocessinginstruction(start: number, length: number): void {
-        this.endIndex = this.tokenizer.getIndex();
-        const value = this.getSubstr(start, length);
+    onprocessinginstruction(start: number, endIndex: number): void {
+        this.endIndex = endIndex;
+        const value = this.getSubstr(start, endIndex - start);
 
         if (this.cbs.onprocessinginstruction) {
             const name = this.getInstructionName(value);

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -224,7 +224,7 @@ export default class Tokenizer {
         return this._index;
     }
 
-    private stateText(c: number) {
+    private stateText(c: number): void {
         if (
             c === CharCodes.Lt ||
             (!this.decodeEntities && this.fastForwardTo(CharCodes.Lt))
@@ -244,7 +244,7 @@ export default class Tokenizer {
 
     private currentSequence!: Uint8Array;
     private sequenceIndex = 0;
-    private stateSpecialStartSequence(c: number) {
+    private stateSpecialStartSequence(c: number): void {
         const isEnd = this.sequenceIndex === this.currentSequence.length;
         const isMatch = isEnd
             ? // If we are at the end of the sequence, make sure the tag name has ended
@@ -265,7 +265,7 @@ export default class Tokenizer {
     }
 
     /** Look for an end tag. For <title> tags, also decode entities. */
-    private stateInSpecialTag(c: number) {
+    private stateInSpecialTag(c: number): void {
         if (this.sequenceIndex === this.currentSequence.length) {
             if (c === CharCodes.Gt || isWhitespace(c)) {
                 const endOfText = this._index - this.currentSequence.length;
@@ -308,7 +308,7 @@ export default class Tokenizer {
         }
     }
 
-    private stateCDATASequence(c: number) {
+    private stateCDATASequence(c: number): void {
         if (c === Sequences.Cdata[this.sequenceIndex]) {
             if (++this.sequenceIndex === Sequences.Cdata.length) {
                 this._state = State.InCommentLike;
@@ -355,7 +355,7 @@ export default class Tokenizer {
      * - That character is then repeated, so we have to check multiple repeats.
      * - All characters but the start character of the sequence can be skipped.
      */
-    private stateInCommentLike(c: number) {
+    private stateInCommentLike(c: number): void {
         if (c === this.currentSequence[this.sequenceIndex]) {
             if (++this.sequenceIndex === this.currentSequence.length) {
                 // Remove 2 trailing chars
@@ -399,7 +399,7 @@ export default class Tokenizer {
         this._state = State.SpecialStartSequence;
     }
 
-    private stateBeforeTagName(c: number) {
+    private stateBeforeTagName(c: number): void {
         if (c === CharCodes.ExclamationMark) {
             this._state = State.BeforeDeclaration;
             this.sectionStart = this._index + 1;
@@ -424,7 +424,7 @@ export default class Tokenizer {
             this.stateText(c);
         }
     }
-    private stateInTagName(c: number) {
+    private stateInTagName(c: number): void {
         if (isEndOfTagSection(c)) {
             this.cbs.onopentagname(
                 this.sectionStart,
@@ -435,7 +435,7 @@ export default class Tokenizer {
             this.stateBeforeAttributeName(c);
         }
     }
-    private stateBeforeClosingTagName(c: number) {
+    private stateBeforeClosingTagName(c: number): void {
         if (isWhitespace(c)) {
             // Ignore
         } else if (c === CharCodes.Gt) {
@@ -447,7 +447,7 @@ export default class Tokenizer {
             this.sectionStart = this._index;
         }
     }
-    private stateInClosingTagName(c: number) {
+    private stateInClosingTagName(c: number): void {
         if (c === CharCodes.Gt || isWhitespace(c)) {
             this.cbs.onclosetag(
                 this.sectionStart,
@@ -458,14 +458,14 @@ export default class Tokenizer {
             this.stateAfterClosingTagName(c);
         }
     }
-    private stateAfterClosingTagName(c: number) {
+    private stateAfterClosingTagName(c: number): void {
         // Skip everything until ">"
         if (c === CharCodes.Gt || this.fastForwardTo(CharCodes.Gt)) {
             this._state = State.Text;
             this.sectionStart = this._index + 1;
         }
     }
-    private stateBeforeAttributeName(c: number) {
+    private stateBeforeAttributeName(c: number): void {
         if (c === CharCodes.Gt) {
             this.cbs.onopentagend();
             if (this.isSpecial) {
@@ -483,7 +483,7 @@ export default class Tokenizer {
             this.sectionStart = this._index;
         }
     }
-    private stateInSelfClosingTag(c: number) {
+    private stateInSelfClosingTag(c: number): void {
         if (c === CharCodes.Gt) {
             this.cbs.onselfclosingtag();
             this._state = State.Text;
@@ -495,7 +495,7 @@ export default class Tokenizer {
             this.stateBeforeAttributeName(c);
         }
     }
-    private stateInAttributeName(c: number) {
+    private stateInAttributeName(c: number): void {
         if (c === CharCodes.Eq || isEndOfTagSection(c)) {
             this.cbs.onattribname(
                 this.sectionStart,
@@ -506,7 +506,7 @@ export default class Tokenizer {
             this.stateAfterAttributeName(c);
         }
     }
-    private stateAfterAttributeName(c: number) {
+    private stateAfterAttributeName(c: number): void {
         if (c === CharCodes.Eq) {
             this._state = State.BeforeAttributeValue;
         } else if (c === CharCodes.Slash || c === CharCodes.Gt) {
@@ -519,7 +519,7 @@ export default class Tokenizer {
             this.sectionStart = this._index;
         }
     }
-    private stateBeforeAttributeValue(c: number) {
+    private stateBeforeAttributeValue(c: number): void {
         if (c === CharCodes.DoubleQuote) {
             this._state = State.InAttributeValueDq;
             this.sectionStart = this._index + 1;
@@ -553,13 +553,13 @@ export default class Tokenizer {
             this._state = State.BeforeEntity;
         }
     }
-    private stateInAttributeValueDoubleQuotes(c: number) {
+    private stateInAttributeValueDoubleQuotes(c: number): void {
         this.handleInAttributeValue(c, CharCodes.DoubleQuote);
     }
-    private stateInAttributeValueSingleQuotes(c: number) {
+    private stateInAttributeValueSingleQuotes(c: number): void {
         this.handleInAttributeValue(c, CharCodes.SingleQuote);
     }
-    private stateInAttributeValueNoQuotes(c: number) {
+    private stateInAttributeValueNoQuotes(c: number): void {
         if (isWhitespace(c) || c === CharCodes.Gt) {
             this.cbs.onattribdata(
                 this.sectionStart,
@@ -574,7 +574,7 @@ export default class Tokenizer {
             this._state = State.BeforeEntity;
         }
     }
-    private stateBeforeDeclaration(c: number) {
+    private stateBeforeDeclaration(c: number): void {
         if (c === CharCodes.OpeningSquareBracket) {
             this._state = State.CDATASequence;
             this.sequenceIndex = 0;
@@ -585,7 +585,7 @@ export default class Tokenizer {
                     : State.InDeclaration;
         }
     }
-    private stateInDeclaration(c: number) {
+    private stateInDeclaration(c: number): void {
         if (c === CharCodes.Gt || this.fastForwardTo(CharCodes.Gt)) {
             this.cbs.ondeclaration(
                 this.sectionStart,
@@ -595,7 +595,7 @@ export default class Tokenizer {
             this.sectionStart = this._index + 1;
         }
     }
-    private stateInProcessingInstruction(c: number) {
+    private stateInProcessingInstruction(c: number): void {
         if (c === CharCodes.Gt || this.fastForwardTo(CharCodes.Gt)) {
             this.cbs.onprocessinginstruction(
                 this.sectionStart,
@@ -605,7 +605,7 @@ export default class Tokenizer {
             this.sectionStart = this._index + 1;
         }
     }
-    private stateBeforeComment(c: number) {
+    private stateBeforeComment(c: number): void {
         if (c === CharCodes.Dash) {
             this._state = State.InCommentLike;
             this.currentSequence = Sequences.CommentEnd;
@@ -616,7 +616,7 @@ export default class Tokenizer {
             this._state = State.InDeclaration;
         }
     }
-    private stateInSpecialComment(c: number) {
+    private stateInSpecialComment(c: number): void {
         if (c === CharCodes.Gt || this.fastForwardTo(CharCodes.Gt)) {
             this.cbs.oncomment(
                 this.sectionStart,
@@ -626,7 +626,7 @@ export default class Tokenizer {
             this.sectionStart = this._index + 1;
         }
     }
-    private stateBeforeSpecialS(c: number) {
+    private stateBeforeSpecialS(c: number): void {
         const lower = c | 0x20;
         if (lower === Sequences.ScriptEnd[3]) {
             this.startSpecial(Sequences.ScriptEnd, 4);
@@ -640,12 +640,13 @@ export default class Tokenizer {
 
     private trieIndex = 0;
     private trieCurrent = 0;
-    private trieResult = 0;
+    private entityResult = 0;
     private entityExcess = 0;
 
-    private stateBeforeEntity(c: number) {
+    private stateBeforeEntity(c: number): void {
         // Start excess with 1 to include the '&'
         this.entityExcess = 1;
+        this.entityResult = 0;
 
         if (c === CharCodes.Num) {
             this._state = State.BeforeNumericEntity;
@@ -654,13 +655,12 @@ export default class Tokenizer {
         } else {
             this.trieIndex = 0;
             this.trieCurrent = this.entityTrie[0];
-            this.trieResult = 0;
             this._state = State.InNamedEntity;
             this.stateInNamedEntity(c);
         }
     }
 
-    private stateInNamedEntity(c: number) {
+    private stateInNamedEntity(c: number): void {
         this.entityExcess += 1;
 
         this.trieIndex = determineBranch(
@@ -696,7 +696,7 @@ export default class Tokenizer {
                 }
 
                 // If this is a surrogate pair, consume the next two bytes
-                this.trieResult = this.trieIndex;
+                this.entityResult = this.trieIndex;
                 this.trieIndex +=
                     1 +
                     Number((this.trieCurrent & BinTrieFlags.MULTI_BYTE) !== 0);
@@ -707,10 +707,10 @@ export default class Tokenizer {
     }
 
     private emitNamedEntity() {
-        if (this.trieResult !== 0) {
-            if (this.entityTrie[this.trieResult] & BinTrieFlags.MULTI_BYTE) {
-                const first = this.entityTrie[this.trieResult + 1];
-                const second = this.entityTrie[this.trieResult + 2];
+        if (this.entityResult !== 0) {
+            if (this.entityTrie[this.entityResult] & BinTrieFlags.MULTI_BYTE) {
+                const first = this.entityTrie[this.entityResult + 1];
+                const second = this.entityTrie[this.entityResult + 2];
                 // If this is a surrogate pair, combine the code points.
                 if (first >= 0xd8_00 && first <= 0xdf_ff) {
                     this.emitCodePoint(
@@ -722,14 +722,14 @@ export default class Tokenizer {
                     this.emitCodePoint(second);
                 }
             } else {
-                this.emitCodePoint(this.entityTrie[this.trieResult + 1]);
+                this.emitCodePoint(this.entityTrie[this.entityResult + 1]);
             }
         }
 
         this._state = this.baseState;
     }
 
-    private stateBeforeNumericEntity(c: number) {
+    private stateBeforeNumericEntity(c: number): void {
         if ((c | 0x20) === CharCodes.LowerX) {
             this.entityExcess++;
             this._state = State.InHexEntity;
@@ -760,7 +760,7 @@ export default class Tokenizer {
         }
         this._state = this.baseState;
     }
-    private stateInNumericEntity(c: number) {
+    private stateInNumericEntity(c: number): void {
         if (c === CharCodes.Semi) {
             this.decodeNumericEntity(10, true);
         } else if (!isNumber(c)) {
@@ -774,7 +774,7 @@ export default class Tokenizer {
             this.entityExcess++;
         }
     }
-    private stateInHexEntity(c: number) {
+    private stateInHexEntity(c: number): void {
         if (c === CharCodes.Semi) {
             this.decodeNumericEntity(16, true);
         } else if (

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -22,7 +22,7 @@ Array [
   Array [
     "onopentagname",
     1,
-    6,
+    7,
   ],
   Array [
     "onselfclosingtag",
@@ -30,7 +30,7 @@ Array [
   Array [
     "onopentagname",
     11,
-    3,
+    14,
   ],
   Array [
     "onopentagend",
@@ -38,7 +38,7 @@ Array [
   Array [
     "onclosetag",
     17,
-    3,
+    20,
   ],
   Array [
     "onend",
@@ -51,7 +51,7 @@ Array [
   Array [
     "onopentagname",
     1,
-    5,
+    6,
   ],
   Array [
     "onselfclosingtag",
@@ -59,7 +59,7 @@ Array [
   Array [
     "onopentagname",
     10,
-    3,
+    13,
   ],
   Array [
     "onopentagend",
@@ -67,7 +67,7 @@ Array [
   Array [
     "onclosetag",
     16,
-    3,
+    19,
   ],
   Array [
     "onend",
@@ -80,7 +80,7 @@ Array [
   Array [
     "onopentagname",
     1,
-    5,
+    6,
   ],
   Array [
     "onselfclosingtag",
@@ -88,7 +88,7 @@ Array [
   Array [
     "onopentagname",
     10,
-    3,
+    13,
   ],
   Array [
     "onopentagend",
@@ -96,7 +96,7 @@ Array [
   Array [
     "onclosetag",
     16,
-    3,
+    19,
   ],
   Array [
     "onend",
@@ -109,7 +109,7 @@ Array [
   Array [
     "onopentagname",
     1,
-    6,
+    7,
   ],
   Array [
     "onopentagend",
@@ -117,12 +117,12 @@ Array [
   Array [
     "onclosetag",
     10,
-    6,
+    16,
   ],
   Array [
     "onopentagname",
     18,
-    3,
+    21,
   ],
   Array [
     "onopentagend",
@@ -130,7 +130,7 @@ Array [
   Array [
     "onclosetag",
     24,
-    3,
+    27,
   ],
   Array [
     "onend",
@@ -143,7 +143,7 @@ Array [
   Array [
     "onopentagname",
     1,
-    5,
+    6,
   ],
   Array [
     "onopentagend",
@@ -151,12 +151,12 @@ Array [
   Array [
     "onclosetag",
     9,
-    5,
+    14,
   ],
   Array [
     "onopentagname",
     16,
-    3,
+    19,
   ],
   Array [
     "onopentagend",
@@ -164,7 +164,7 @@ Array [
   Array [
     "onclosetag",
     22,
-    3,
+    25,
   ],
   Array [
     "onend",
@@ -177,7 +177,7 @@ Array [
   Array [
     "onopentagname",
     1,
-    5,
+    6,
   ],
   Array [
     "onopentagend",
@@ -185,12 +185,12 @@ Array [
   Array [
     "onclosetag",
     9,
-    5,
+    14,
   ],
   Array [
     "onopentagname",
     16,
-    3,
+    19,
   ],
   Array [
     "onopentagend",
@@ -198,7 +198,7 @@ Array [
   Array [
     "onclosetag",
     22,
-    3,
+    25,
   ],
   Array [
     "onend",

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -9,7 +9,7 @@ Array [
   Array [
     "ontext",
     5,
-    7,
+    12,
   ],
   Array [
     "onend",
@@ -26,6 +26,7 @@ Array [
   ],
   Array [
     "onselfclosingtag",
+    9,
   ],
   Array [
     "onopentagname",
@@ -34,6 +35,7 @@ Array [
   ],
   Array [
     "onopentagend",
+    14,
   ],
   Array [
     "onclosetag",
@@ -55,6 +57,7 @@ Array [
   ],
   Array [
     "onselfclosingtag",
+    8,
   ],
   Array [
     "onopentagname",
@@ -63,6 +66,7 @@ Array [
   ],
   Array [
     "onopentagend",
+    13,
   ],
   Array [
     "onclosetag",
@@ -84,6 +88,7 @@ Array [
   ],
   Array [
     "onselfclosingtag",
+    8,
   ],
   Array [
     "onopentagname",
@@ -92,6 +97,7 @@ Array [
   ],
   Array [
     "onopentagend",
+    13,
   ],
   Array [
     "onclosetag",
@@ -113,6 +119,7 @@ Array [
   ],
   Array [
     "onopentagend",
+    7,
   ],
   Array [
     "onclosetag",
@@ -126,6 +133,7 @@ Array [
   ],
   Array [
     "onopentagend",
+    21,
   ],
   Array [
     "onclosetag",
@@ -147,6 +155,7 @@ Array [
   ],
   Array [
     "onopentagend",
+    6,
   ],
   Array [
     "onclosetag",
@@ -160,6 +169,7 @@ Array [
   ],
   Array [
     "onopentagend",
+    19,
   ],
   Array [
     "onclosetag",
@@ -181,6 +191,7 @@ Array [
   ],
   Array [
     "onopentagend",
+    6,
   ],
   Array [
     "onclosetag",
@@ -194,6 +205,7 @@ Array [
   ],
   Array [
     "onopentagend",
+    19,
   ],
   Array [
     "onclosetag",

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -3,12 +3,13 @@
 exports[`Tokenizer should not lose data when pausing 1`] = `
 Array [
   Array [
-    "ontext",
-    "&",
+    "ontextentity",
+    38,
   ],
   Array [
     "ontext",
-    " it up!",
+    5,
+    7,
   ],
   Array [
     "onend",
@@ -20,21 +21,24 @@ exports[`Tokenizer should support self-closing special tags for self-closing scr
 Array [
   Array [
     "onopentagname",
-    "script",
+    1,
+    6,
   ],
   Array [
     "onselfclosingtag",
   ],
   Array [
     "onopentagname",
-    "div",
+    11,
+    3,
   ],
   Array [
     "onopentagend",
   ],
   Array [
     "onclosetag",
-    "div",
+    17,
+    3,
   ],
   Array [
     "onend",
@@ -46,21 +50,24 @@ exports[`Tokenizer should support self-closing special tags for self-closing sty
 Array [
   Array [
     "onopentagname",
-    "style",
+    1,
+    5,
   ],
   Array [
     "onselfclosingtag",
   ],
   Array [
     "onopentagname",
-    "div",
+    10,
+    3,
   ],
   Array [
     "onopentagend",
   ],
   Array [
     "onclosetag",
-    "div",
+    16,
+    3,
   ],
   Array [
     "onend",
@@ -72,21 +79,24 @@ exports[`Tokenizer should support self-closing special tags for self-closing tit
 Array [
   Array [
     "onopentagname",
-    "title",
+    1,
+    5,
   ],
   Array [
     "onselfclosingtag",
   ],
   Array [
     "onopentagname",
-    "div",
+    10,
+    3,
   ],
   Array [
     "onopentagend",
   ],
   Array [
     "onclosetag",
-    "div",
+    16,
+    3,
   ],
   Array [
     "onend",
@@ -98,25 +108,29 @@ exports[`Tokenizer should support standard special tags for normal script tag 1`
 Array [
   Array [
     "onopentagname",
-    "script",
+    1,
+    6,
   ],
   Array [
     "onopentagend",
   ],
   Array [
     "onclosetag",
-    "script",
+    10,
+    6,
   ],
   Array [
     "onopentagname",
-    "div",
+    18,
+    3,
   ],
   Array [
     "onopentagend",
   ],
   Array [
     "onclosetag",
-    "div",
+    24,
+    3,
   ],
   Array [
     "onend",
@@ -128,25 +142,29 @@ exports[`Tokenizer should support standard special tags for normal sitle tag 1`]
 Array [
   Array [
     "onopentagname",
-    "title",
+    1,
+    5,
   ],
   Array [
     "onopentagend",
   ],
   Array [
     "onclosetag",
-    "title",
+    9,
+    5,
   ],
   Array [
     "onopentagname",
-    "div",
+    16,
+    3,
   ],
   Array [
     "onopentagend",
   ],
   Array [
     "onclosetag",
-    "div",
+    22,
+    3,
   ],
   Array [
     "onend",
@@ -158,25 +176,29 @@ exports[`Tokenizer should support standard special tags for normal style tag 1`]
 Array [
   Array [
     "onopentagname",
-    "style",
+    1,
+    5,
   ],
   Array [
     "onopentagend",
   ],
   Array [
     "onclosetag",
-    "style",
+    9,
+    5,
   ],
   Array [
     "onopentagname",
-    "div",
+    16,
+    3,
   ],
   Array [
     "onopentagend",
   ],
   Array [
     "onclosetag",
-    "div",
+    22,
+    3,
   ],
   Array [
     "onend",


### PR DESCRIPTION
Refactors tokenizer callbacks to pass indices instead of strings. This allows us to avoid most string concatenations, which will speed things up in production.

This should also help with memory bloat: V8 [doesn't garbage collect](https://bugs.chromium.org/p/v8/issues/detail?id=2869) strings with slices still being referenced.

Note: AndreasMadsen/htmlparser-benchmark only parses whole documents. As a consequence, there is no speedup with this change.