### PR TITLE
tests: update Events/07 test to clarify interpretation of tag end slashes

### DIFF
--- a/src/__fixtures__/Events/07a-end_slash--void.json
+++ b/src/__fixtures__/Events/07a-end_slash--void.json
@@ -1,0 +1,48 @@
+{
+    "name": "end slash: void element ending with />",
+    "input": "<hr / ><p>Hold the line.",
+    "expected": [
+        {
+            "event": "opentagname",
+            "startIndex": 0,
+            "endIndex": 3,
+            "data": ["hr"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["hr", {}, false]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["hr", true]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 10,
+            "endIndex": 23,
+            "data": ["Hold the line."]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 24,
+            "endIndex": 24,
+            "data": ["p", true]
+        }
+    ]
+}

--- a/src/__fixtures__/Events/07b-end_slash--void_without.json
+++ b/src/__fixtures__/Events/07b-end_slash--void_without.json
@@ -1,0 +1,48 @@
+{
+    "name": "end slash: void element ending with >",
+    "input": "<hr   ><p>Hold the line.",
+    "expected": [
+        {
+            "event": "opentagname",
+            "startIndex": 0,
+            "endIndex": 3,
+            "data": ["hr"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["hr", {}, false]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["hr", true]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 10,
+            "endIndex": 23,
+            "data": ["Hold the line."]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 24,
+            "endIndex": 24,
+            "data": ["p", true]
+        }
+    ]
+}

--- a/src/__fixtures__/Events/07c-end_slash--void_without--xmlMode.json
+++ b/src/__fixtures__/Events/07c-end_slash--void_without--xmlMode.json
@@ -1,0 +1,53 @@
+{
+    "name": "end slash: void element ending with >, xmlMode=true",
+    "input": "<hr   ><p>Hold the line.",
+    "options": {
+        "parser": {
+            "xmlMode": true
+        }
+    },
+    "expected": [
+        {
+            "event": "opentagname",
+            "startIndex": 0,
+            "endIndex": 3,
+            "data": ["hr"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["hr", {}, false]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 10,
+            "endIndex": 23,
+            "data": ["Hold the line."]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 24,
+            "endIndex": 24,
+            "data": ["p", true]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 24,
+            "endIndex": 24,
+            "data": ["hr", true]
+        }
+    ]
+}

--- a/src/__fixtures__/Events/07d-end_slash--non_void.json
+++ b/src/__fixtures__/Events/07d-end_slash--non_void.json
@@ -1,0 +1,48 @@
+{
+    "name": "end slash: non-void element ending with />",
+    "input": "<xx / ><p>Hold the line.",
+    "expected": [
+        {
+            "event": "opentagname",
+            "startIndex": 0,
+            "endIndex": 3,
+            "data": ["xx"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["xx", {}, false]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 10,
+            "endIndex": 23,
+            "data": ["Hold the line."]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 24,
+            "endIndex": 24,
+            "data": ["p", true]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 24,
+            "endIndex": 24,
+            "data": ["xx", true]
+        }
+    ]
+}

--- a/src/__fixtures__/Events/07e-end_slash--non_void--xmlmode.json
+++ b/src/__fixtures__/Events/07e-end_slash--non_void--xmlmode.json
@@ -1,0 +1,53 @@
+{
+    "name": "end slash: non-void element ending with />, xmlMode=true",
+    "input": "<xx / ><p>Hold the line.",
+    "options": {
+        "parser": {
+            "xmlMode": true
+        }
+    },
+    "expected": [
+        {
+            "event": "opentagname",
+            "startIndex": 0,
+            "endIndex": 3,
+            "data": ["xx"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["xx", {}, false]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["xx", true]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 10,
+            "endIndex": 23,
+            "data": ["Hold the line."]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 24,
+            "endIndex": 24,
+            "data": ["p", true]
+        }
+    ]
+}

--- a/src/__fixtures__/Events/07f-end_slash--non_void--recognize_self_closing.json
+++ b/src/__fixtures__/Events/07f-end_slash--non_void--recognize_self_closing.json
@@ -1,0 +1,53 @@
+{
+    "name": "end slash: non-void element ending with />, recognizeSelfClosing=true",
+    "input": "<xx / ><p>Hold the line.",
+    "options": {
+        "parser": {
+            "recognizeSelfClosing": true
+        }
+    },
+    "expected": [
+        {
+            "event": "opentagname",
+            "startIndex": 0,
+            "endIndex": 3,
+            "data": ["xx"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["xx", {}, false]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 0,
+            "endIndex": 6,
+            "data": ["xx", true]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 7,
+            "endIndex": 9,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 10,
+            "endIndex": 23,
+            "data": ["Hold the line."]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 24,
+            "endIndex": 24,
+            "data": ["p", true]
+        }
+    ]
+}

--- a/src/__fixtures__/Events/07g-end_slash--consumed_by_attrib_value_in_void.json
+++ b/src/__fixtures__/Events/07g-end_slash--consumed_by_attrib_value_in_void.json
@@ -1,0 +1,54 @@
+{
+    "name": "end slash: as part of attrib value of void element",
+    "input": "<img src=gif.com/123/><p>Hold the line.",
+    "expected": [
+        {
+            "event": "opentagname",
+            "startIndex": 0,
+            "endIndex": 4,
+            "data": ["img"]
+        },
+        {
+            "event": "attribute",
+            "startIndex": 5,
+            "endIndex": 21,
+            "data": ["src", "gif.com/123/", null]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 0,
+            "endIndex": 21,
+            "data": ["img", { "src": "gif.com/123/" }, false]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 0,
+            "endIndex": 21,
+            "data": ["img", true]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 22,
+            "endIndex": 24,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 22,
+            "endIndex": 24,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 25,
+            "endIndex": 38,
+            "data": ["Hold the line."]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 39,
+            "endIndex": 39,
+            "data": ["p", true]
+        }
+    ]
+}

--- a/src/__fixtures__/Events/07h-end_slash--consumed_by_attrib_value_in_non_void.json
+++ b/src/__fixtures__/Events/07h-end_slash--consumed_by_attrib_value_in_non_void.json
@@ -1,6 +1,6 @@
 {
-    "name": "Self-closing tags",
-    "input": "<a href=http://test.com/>Foo</a><hr / >",
+    "name": "end slash: as part of attrib value of non-void element",
+    "input": "<a href=http://test.com/>Foo</a><p>Hold the line.",
     "expected": [
         {
             "event": "opentagname",
@@ -18,13 +18,7 @@
             "event": "opentag",
             "startIndex": 0,
             "endIndex": 24,
-            "data": [
-                "a",
-                {
-                    "href": "http://test.com/"
-                },
-                false
-            ]
+            "data": ["a", { "href": "http://test.com/" }, false]
         },
         {
             "event": "text",
@@ -41,20 +35,26 @@
         {
             "event": "opentagname",
             "startIndex": 32,
-            "endIndex": 35,
-            "data": ["hr"]
+            "endIndex": 34,
+            "data": ["p"]
         },
         {
             "event": "opentag",
             "startIndex": 32,
-            "endIndex": 38,
-            "data": ["hr", {}, false]
+            "endIndex": 34,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 35,
+            "endIndex": 48,
+            "data": ["Hold the line."]
         },
         {
             "event": "closetag",
-            "startIndex": 32,
-            "endIndex": 38,
-            "data": ["hr", true]
+            "startIndex": 49,
+            "endIndex": 49,
+            "data": ["p", true]
         }
     ]
 }


### PR DESCRIPTION
This PR contains suggested enhancements to the `Events/07-self-closing.json`  test.

It also suggests a testing strategy that can be applied in other cases: a set of tests where the input and context are identical except for one isolated change. The outputs can thereby be diffed, showing the effect of the isolated change.

No worries if this isn't merged. Also happy to make any changes desired changes. 


## Test 07 enhancements

The original `07-self-closing.json` covered two cases:

- a tag ending in `/>` but where the `/` is in fact part of the attribute value -- thus *not* a self-closing tag

- an HTML void element, `<hr>`, in XHTML self-closing style.

  One flaw with this test is that `hr` is also a void element: While the test passes because the expected `closetag` event occurs, one doesn't know if it occurs because of the end slash or because it is a void element. 

  The test `07-self-closing.json` only included a self-closing tag for a void element. This made the test ambiguous in purpose if you didn't know that htmlparser2 followed the above distinction.

The new `07a` to `07h` tests cover much more:

- base name for all these tests is "end slash" rather than "self-closing" because what's being tested is how that end slash is interpreted in different contexts, e.g. as the mark of a self-closing tag, a part of the attribute, or ignored entirely.

- each of the 8 tests represents one isolated change compared to one or more of the others:

  - void vs non-void
  - with and without end slash
  - `xmlMode` off vs on
  - `recognizeSelfClosing` off vs on
  - end slash attached to unquoted attribute value

  This allows one to diff the event streams to see the effect of that isolated change. For example, you can compare:

  - 07a with 07d to see that `<hr/>` generates a `closetag` event while `<xx/>` does not. The former is a void element and the latter is not. 
  - 07x with 07y to see the effect of xmlMode.



## `recognizeSelfClosing` test coverage and test demonstrated semantics

This option was introduced in https://github.com/fb55/htmlparser2/pull/74 but without any tests nor any documentation. 

I confirmed there is no test coverage by:

1. Temporarily adding the following line to `Parser.ts`'s constructor:

   ```
   this.options.recognizeSelfClosing = !this.options.recognizeSelfClosing
   ```

2. Ran the tests. **No tests failed.** The above change inverted the option for every test, and would have caused any test covering this option to fail.

I added coverage via case `07f`

There is no clear documentation on the semantics of `recognizeSelfClosing`, but based on the new `07` tests and diffing their outputs, I was able to surmise the following:

> #### 🌶 `recognizeSelfClosing` really means "recognized *all* tags ending with `/>` as self-closing in normal HTML mode (as if in xmlMode), not just void element tags"


