### PR TITLE
refactor(parser): Highlight special close-implies-open logic

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -334,14 +334,15 @@ export class Parser {
                     }
                 } else this.stack.length = pos;
             } else if (!this.options.xmlMode && name === "p") {
-                this.emitOpenTag(name);
+                // Implicit open before close
+                this.emitOpenTag("p");
                 this.closeCurrentTag(true);
             }
         } else if (!this.options.xmlMode && name === "br") {
-            // We can't go through `emitOpenTag` here, as `br` would be implicitly closed.
-            this.cbs.onopentagname?.(name);
-            this.cbs.onopentag?.(name, {}, true);
-            this.cbs.onclosetag?.(name, false);
+            // We can't use `emitOpenTag` for implicit open, as `br` would be implicitly closed.
+            this.cbs.onopentagname?.("br");
+            this.cbs.onopentag?.("br", {}, true);
+            this.cbs.onclosetag?.("br", false);
         }
 
         // Set `startIndex` for next node


### PR DESCRIPTION
Only `</p>` and `</br>` close tags result in implied open tags:
- [onclosetag logic for `p`](https://github.com/fb55/htmlparser2/blob/6445c32b05dc070049eeaaf201bfc123daca3d37/src/Parser.ts#L336)
- [onclosetag logic for `br`](https://github.com/fb55/htmlparser2/blob/6445c32b05dc070049eeaaf201bfc123daca3d37/src/Parser.ts#L340)

This commit clarifies this in the existing comments. It also
makes the special case nature of this more apparent by using
the literal values 'p' and 'br' instead of the variable `name`,
which is proven to have these values. This is less obfuscating.
