### PR TITLE
Fixed uncatchable error

### DIFF
--- a/src/WritableStream.ts
+++ b/src/WritableStream.ts
@@ -25,11 +25,15 @@ export class WritableStream extends Writable {
         this._parser = new Parser(cbs, options);
     }
 
-    _write(chunk: string | Buffer, encoding: string, cb: () => void): void {
-        this._parser.write(
-            isBuffer(chunk, encoding) ? this._decoder.write(chunk) : chunk
-        );
-        cb();
+    _write(chunk: string | Buffer, encoding: string, cb:(err?: any) => void): void {
+        try {
+            this._parser.write(
+                isBuffer(chunk, encoding) ? this._decoder.write(chunk) : chunk
+            );
+            cb();
+        } catch (e) {
+            cb(e);
+        }
     }
 
     _final(cb: () => void): void {


### PR DESCRIPTION
Error was occuring when you tried to pipe writable stream with readfilestream (https://github.com/fb55/htmlparser2/issues/866)

Parser may throw an error, but the error is not passed to the callback, as Nodejs documentation about implementing a writable stream (https://nodejs.org/dist/latest-v14.x/docs/api/stream.html#stream_writable_write_chunk_encoding_callback_1)