### PR TITLE
chore(tests): Add test cases for misnested tags

### DIFF
--- a/src/__fixtures__/Events/47-misnested-formatting-tags.json
+++ b/src/__fixtures__/Events/47-misnested-formatting-tags.json
@@ -1,0 +1,90 @@
+{
+    "name": "misnested formatting tags",
+    "input": "plain <b>bold <i>italic bold </b>italic </i>plain",
+    "expected": [
+        {
+            "event": "text",
+            "startIndex": 0,
+            "endIndex": 5,
+            "data": ["plain "]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 6,
+            "endIndex": 8,
+            "data": ["b"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 6,
+            "endIndex": 8,
+            "data": ["b", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 9,
+            "endIndex": 13,
+            "data": ["bold "]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 14,
+            "endIndex": 16,
+            "data": ["i"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 14,
+            "endIndex": 16,
+            "data": ["i", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 17,
+            "endIndex": 28,
+            "data": ["italic bold "]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 29,
+            "endIndex": 32,
+            "data": ["i", true]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 29,
+            "endIndex": 32,
+            "data": ["b", false]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 29,
+            "endIndex": 32,
+            "data": ["i"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 29,
+            "endIndex": 32,
+            "data": ["i", {}, true]
+        },
+        {
+            "event": "text",
+            "startIndex": 33,
+            "endIndex": 39,
+            "data": ["italic "]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 40,
+            "endIndex": 43,
+            "data": ["i", false]
+        },
+        {
+            "event": "text",
+            "startIndex": 44,
+            "endIndex": 48,
+            "data": ["plain"]
+        }
+    ]
+}

--- a/src/__fixtures__/Events/48-misnested-formatting-and-block-tags.json
+++ b/src/__fixtures__/Events/48-misnested-formatting-and-block-tags.json
@@ -1,0 +1,162 @@
+{
+    "name": "misnested formatting and block tags",
+    "input": "<p>plain <b>bold  <p><i>italic bold <p></b> italic </i> plain",
+    "expected": [
+        {
+            "event": "opentagname",
+            "startIndex": 0,
+            "endIndex": 2,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 0,
+            "endIndex": 2,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 3,
+            "endIndex": 8,
+            "data": ["plain "]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 9,
+            "endIndex": 11,
+            "data": ["b"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 9,
+            "endIndex": 11,
+            "data": ["b", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 12,
+            "endIndex": 17,
+            "data": ["bold  "]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 18,
+            "endIndex": 20,
+            "data": ["b", true]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 18,
+            "endIndex": 20,
+            "data": ["p", true]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 18,
+            "endIndex": 20,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 18,
+            "endIndex": 20,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 18,
+            "endIndex": 20,
+            "data": ["b"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 18,
+            "endIndex": 20,
+            "data": ["b", {}, true]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 21,
+            "endIndex": 23,
+            "data": ["i"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 21,
+            "endIndex": 23,
+            "data": ["i", {}, false]
+        },
+        {
+            "event": "text",
+            "startIndex": 24,
+            "endIndex": 35,
+            "data": ["italic bold "]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 36,
+            "endIndex": 38,
+            "data": ["i", true]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 36,
+            "endIndex": 38,
+            "data": ["b", true]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 36,
+            "endIndex": 38,
+            "data": ["p", true]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 36,
+            "endIndex": 38,
+            "data": ["p"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 36,
+            "endIndex": 38,
+            "data": ["p", {}, false]
+        },
+        {
+            "event": "opentagname",
+            "startIndex": 36,
+            "endIndex": 38,
+            "data": ["i"]
+        },
+        {
+            "event": "opentag",
+            "startIndex": 36,
+            "endIndex": 38,
+            "data": ["i", {}, true]
+        },
+        {
+            "event": "text",
+            "startIndex": 43,
+            "endIndex": 50,
+            "data": [" italic "]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 51,
+            "endIndex": 54,
+            "data": ["i", false]
+        },
+        {
+            "event": "text",
+            "startIndex": 55,
+            "endIndex": 60,
+            "data": [" plain"]
+        },
+        {
+            "event": "closetag",
+            "startIndex": 61,
+            "endIndex": 61,
+            "data": ["p", true]
+        }
+    ]
+}


### PR DESCRIPTION
> ### 🚩The tests are expected to fail (currently) and I don't expect this PR to be accepted (yet)
> This PR adds tests that compares current behavior to what I think the behavior should be.
> This of course is not my call. My intention is to seed a discussion.

These new tests demonstrate Issues #1075 and #1076. They will of course fail as the current code does not behave as described in those issues or these tests.

- `47-misnested-formatting-tags.json` demonstrates and covers Issue #1075.

- `48-misnested-formatting-and-block-tags.json` demonstrates and covers both
Issue #1075 and Issue #1076.

