### PR TITLE
docs(readme): Add message in README steering people to parse5 if they need HTML5 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The fast & forgiving HTML/XML parser.
 
-*htmlparser2 is [the fastest HTML parser](#performance), and takes some shortcuts to get there. If you need strict HTML spec compliance, have a look at [parse5](https://github.com/inikulin/parse5).*
+_htmlparser2 is [the fastest HTML parser](#performance), and takes some shortcuts to get there. If you need strict HTML spec compliance, have a look at [parse5](https://github.com/inikulin/parse5)._
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The fast & forgiving HTML/XML parser.
 
-> *For speed, choose htmlparser2. It's [the fastest](#performance). If you need HTML5 spec compliance, choose [parse5](https://github.com/inikulin/parse5).*
+*htmlparser2 is [the fastest HTML parser](#performance), and takes some shortcuts to get there. If you need strict HTML spec compliance, have a look at [parse5](https://github.com/inikulin/parse5).*
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 The fast & forgiving HTML/XML parser.
 
+> *For speed, choose htmlparser2. It's [the fastest](#performance). If you need HTML5 spec compliance, choose [parse5](https://github.com/inikulin/parse5).*
+
 ## Installation
 
     npm install htmlparser2


### PR DESCRIPTION
I think this is important to steer people to htmlparser2 or parse5 based on this key difference, especially since this difference is fundamental and permanent.  It's important to do this up front to save people the time and effort of finding out the hard way.

Fixes #1075

Happy to reword or make any other changes you want, or drop this and leave it all to you :)

