### PR TITLE
Make types available via package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
     "exports": {
         ".": {
             "require": "./lib/index.js",
-            "import": "./lib/esm/index.js"
+            "import": "./lib/esm/index.js",
+            "types": "./lib/index.d.ts",
         },
         "./lib/WritableStream": {
             "require": "./lib/WritableStream.js",
-            "import": "./lib/esm/WritableStream.js"
+            "import": "./lib/esm/WritableStream.js",
+            "types": "./lib/WritableStream.d.ts",
         }
     },
     "files": [


### PR DESCRIPTION
This is needed for TypeScript 4.7, otherwise it can't find the declaration files.