### PR TITLE
add missing package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "htmlparser2",
     "description": "Fast & forgiving HTML/XML parser",
-    "version": "8.0.1",
+    "version": "8.0.2",
     "author": "Felix Boehm <me@feedic.com>",
     "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,14 @@
         "./lib/WritableStream": {
             "require": "./lib/WritableStream.js",
             "import": "./lib/esm/WritableStream.js"
+        },
+        "./lib/Parser":{
+            "require": "./lib/Parser.js",
+            "import": "./lib/esm/Parser.js"
+        },
+        "./lib/Tokenizer":{
+            "require": "./lib/Tokenizer.js",
+            "import": "./lib/esm/Tokenizer.js"
         }
     },
     "files": [

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
             "require": "./lib/WritableStream.js",
             "import": "./lib/esm/WritableStream.js"
         },
-        "./lib/Parser":{
+        "./lib/Parser": {
             "require": "./lib/Parser.js",
             "import": "./lib/esm/Parser.js"
         },
-        "./lib/Tokenizer":{
+        "./lib/Tokenizer": {
             "require": "./lib/Tokenizer.js",
             "import": "./lib/esm/Tokenizer.js"
         }


### PR DESCRIPTION
Exporting *all* files can help when trying to tree shake with webpack or another bundler.

other wise it may throw an error when trying to tree shake
```
Module not found: Error: Package path ./lib/Parser is not exported from package 
~\node_modules\htmlparser2 (see exports field in ~\node_modules\htmlparser2\package.json)

webpack 5.74.0 compiled with 1 error and 1 warning in 333 ms
```

For those who want to tree shake:
```js
const { Parser: Parser2, parseDOM } = require('htmlparser2'); // 48 kb - normally (webpack)
const { Parser } = require('htmlparser2/lib/Parser'); // 31 kb - tree shaking (webpack)
```