### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -11,6 +11,9 @@ env:
     FORCE_COLOR: 2
     NODE_COV: lts/* # The Node.js version to run coveralls on
 
+permissions:
+  contents: read #  to fetch code (actions/checkout)
+
 jobs:
     lint:
         runs-on: ubuntu-latest
@@ -24,6 +27,10 @@ jobs:
             - run: npm run lint
 
     test:
+        permissions:
+          contents: read #  to fetch code (actions/checkout)
+          checks: write #  to create new checks (coverallsapp/github-action)
+
         name: Node ${{ matrix.node }}
         runs-on: ubuntu-latest
 

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -12,7 +12,7 @@ env:
     NODE_COV: lts/* # The Node.js version to run coveralls on
 
 permissions:
-  contents: read #  to fetch code (actions/checkout)
+    contents: read #  to fetch code (actions/checkout)
 
 jobs:
     lint:
@@ -28,8 +28,8 @@ jobs:
 
     test:
         permissions:
-          contents: read #  to fetch code (actions/checkout)
-          checks: write #  to create new checks (coverallsapp/github-action)
+            contents: read #  to fetch code (actions/checkout)
+            checks: write #  to create new checks (coverallsapp/github-action)
 
         name: Node ${{ matrix.node }}
         runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.