### PR TITLE
Export WritableStream for easier Typescript integration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export {
     type DomHandlerOptions,
 } from "domhandler";
 
+export { WritableStream } from "./WritableStream.js";
+
 export type Options = ParserOptions & DomHandlerOptions;
 
 // Helper methods


### PR DESCRIPTION
This makes it easier (possible?) to use WritableStream from within another Typescript application.

I was having trouble using:

`import { WritableStream } from 'htmlparser2/lib/WritableStream';`

