### PR TITLE
Reset baseState after closing tag name

### DIFF
--- a/src/Tokenizer.spec.ts
+++ b/src/Tokenizer.spec.ts
@@ -47,6 +47,15 @@ describe("Tokenizer", () => {
         });
     });
 
+    describe("should not break after special tag followed by an entity", () => {
+        it("for normal special tag", () => {
+            expect(tokenize("<style>a{}</style>&apos;<br/>")).toMatchSnapshot();
+        });
+        it("for self-closing special tag", () => {
+            expect(tokenize("<style />&apos;<br/>")).toMatchSnapshot();
+        });
+    });
+
     it("should not lose data when pausing", () => {
         const log: unknown[][] = [];
         const tokenizer = new Tokenizer(

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -455,6 +455,7 @@ export default class Tokenizer {
         // Skip everything until ">"
         if (c === CharCodes.Gt || this.fastForwardTo(CharCodes.Gt)) {
             this.state = State.Text;
+            this.baseState = State.Text;
             this.sectionStart = this.index + 1;
         }
     }

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -1,5 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Tokenizer should not break after special tag followed by an entity for normal special tag 1`] = `
+[
+  [
+    "onopentagname",
+    1,
+    6,
+  ],
+  [
+    "onopentagend",
+    6,
+  ],
+  [
+    "ontext",
+    7,
+    10,
+  ],
+  [
+    "onclosetag",
+    12,
+    17,
+  ],
+  [
+    "ontextentity",
+    39,
+  ],
+  [
+    "onopentagname",
+    25,
+    27,
+  ],
+  [
+    "onselfclosingtag",
+    28,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
+exports[`Tokenizer should not break after special tag followed by an entity for self-closing special tag 1`] = `
+[
+  [
+    "onopentagname",
+    1,
+    6,
+  ],
+  [
+    "onselfclosingtag",
+    8,
+  ],
+  [
+    "ontextentity",
+    39,
+  ],
+  [
+    "onopentagname",
+    16,
+    18,
+  ],
+  [
+    "onselfclosingtag",
+    19,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
 exports[`Tokenizer should not lose data when pausing 1`] = `
 [
   [


### PR DESCRIPTION
Prevents leaking baseState and breaking the Tokenizer if followed by an entity - #1426