### PR TITLE
refactor(tokenizer): Use `EntityDecoder`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.3",
                 "domutils": "^3.0.1",
-                "entities": "^4.4.0"
+                "entities": "^4.5.0"
             },
             "devDependencies": {
                 "@types/jest": "^29.5.0",
@@ -2135,9 +2135,9 @@
             "dev": true
         },
         "node_modules/entities": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "engines": {
                 "node": ">=0.12"
             },
@@ -6752,9 +6752,9 @@
             "dev": true
         },
         "entities": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         },
         "error-ex": {
             "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
     },
     "devDependencies": {
         "@types/jest": "^29.5.0",

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -251,15 +251,10 @@ export class Parser implements Callbacks {
     }
 
     /** @internal */
-    ontextentity(cp: number): void {
-        /*
-         * Entities can be emitted on the character, or directly after.
-         * We use the section start here to get accurate indices.
-         */
-        const index = this.tokenizer.getSectionStart();
-        this.endIndex = index - 1;
+    ontextentity(cp: number, endIndex: number): void {
+        this.endIndex = endIndex - 1;
         this.cbs.ontext?.(fromCodePoint(cp));
-        this.startIndex = index;
+        this.startIndex = endIndex;
     }
 
     protected isVoidElement(name: string): boolean {

--- a/src/Tokenizer.spec.ts
+++ b/src/Tokenizer.spec.ts
@@ -1,10 +1,10 @@
 import { Tokenizer } from "./index.js";
 import type { Callbacks } from "./Tokenizer.js";
 
-function tokenize(data: string) {
+function tokenize(data: string, options = {}) {
     const log: unknown[][] = [];
     const tokenizer = new Tokenizer(
-        {},
+        options,
         new Proxy(
             {},
             {
@@ -55,6 +55,13 @@ describe("Tokenizer", () => {
             expect(tokenize("<style />&apos;<br/>")).toMatchSnapshot();
         });
     });
+
+    it("should support XML entities", () =>
+        expect(
+            tokenize("&amp;&gt;&amp&lt;&uuml;&#x61;&#x62&#99;&#100&#101", {
+                xmlMode: true,
+            })
+        ).toMatchSnapshot());
 
     it("should not lose data when pausing", () => {
         const log: unknown[][] = [];

--- a/src/Tokenizer.spec.ts
+++ b/src/Tokenizer.spec.ts
@@ -97,7 +97,8 @@ describe("Tokenizer", () => {
             ) as Callbacks
         );
 
-        tokenizer.write("&amp; it up!");
+        tokenizer.write("&am");
+        tokenizer.write("p; it up!");
         tokenizer.resume();
         tokenizer.resume();
 

--- a/src/Tokenizer.spec.ts
+++ b/src/Tokenizer.spec.ts
@@ -56,12 +56,27 @@ describe("Tokenizer", () => {
         });
     });
 
-    it("should support XML entities", () =>
-        expect(
-            tokenize("&amp;&gt;&amp&lt;&uuml;&#x61;&#x62&#99;&#100&#101", {
-                xmlMode: true,
-            })
-        ).toMatchSnapshot());
+    describe("should handle entities", () => {
+        it("for XML entities", () =>
+            expect(
+                tokenize("&amp;&gt;&amp&lt;&uuml;&#x61;&#x62&#99;&#100&#101", {
+                    xmlMode: true,
+                })
+            ).toMatchSnapshot());
+
+        it("for entities in attributes (#276)", () =>
+            expect(
+                tokenize(
+                    '<img src="?&image_uri=1&&image;=2&image=3"/>?&image_uri=1&&image;=2&image=3'
+                )
+            ).toMatchSnapshot());
+
+        it("for trailing legacy entity", () =>
+            expect(tokenize("&timesbar;&timesbar")).toMatchSnapshot());
+
+        it("for multi-byte entities", () =>
+            expect(tokenize("&NotGreaterFullEqual;")).toMatchSnapshot());
+    });
 
     it("should not lose data when pausing", () => {
         const log: unknown[][] = [];

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -118,7 +118,7 @@ export interface Callbacks {
     onprocessinginstruction(start: number, endIndex: number): void;
     onselfclosingtag(endIndex: number): void;
     ontext(start: number, endIndex: number): void;
-    ontextentity(codepoint: number): void;
+    ontextentity(codepoint: number, endIndex: number): void;
 }
 
 /**
@@ -205,20 +205,6 @@ export default class Tokenizer {
         if (this.index < this.buffer.length + this.offset) {
             this.parse();
         }
-    }
-
-    /**
-     * The current index within all of the written data.
-     */
-    public getIndex(): number {
-        return this.index;
-    }
-
-    /**
-     * The start of the current section.
-     */
-    public getSectionStart(): number {
-        return this.sectionStart;
     }
 
     private stateText(c: number): void {
@@ -839,7 +825,7 @@ export default class Tokenizer {
             this.sectionStart = this.entityStart + consumed;
             this.index = this.sectionStart - 1;
 
-            this.cbs.ontextentity(cp);
+            this.cbs.ontextentity(cp, this.sectionStart);
         }
     }
 }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -625,6 +625,10 @@ export default class Tokenizer {
         // If `length` is positive, we are done with the entity.
         if (length >= 0) {
             this.state = this.baseState;
+
+            if (length === 0) {
+                this.index = this.entityStart + 1;
+            }
         }
     }
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -624,7 +624,7 @@ export default class Tokenizer {
             this.state = this.baseState;
 
             if (length === 0) {
-                this.index = this.entityStart + 1;
+                this.index = this.entityStart;
             }
         }
     }
@@ -777,16 +777,20 @@ export default class Tokenizer {
             this.state = this.baseState;
         }
 
-        // If there is remaining data, emit it in a reasonable way
-        if (this.sectionStart < this.index) {
-            this.handleTrailingData();
-        }
+        this.handleTrailingData();
+
         this.cbs.onend();
     }
 
     /** Handle any trailing data. */
     private handleTrailingData() {
         const endIndex = this.buffer.length + this.offset;
+
+        // If there is no remaining data, we are done.
+        if (this.sectionStart >= endIndex) {
+            return;
+        }
+
         if (this.state === State.InCommentLike) {
             if (this.currentSequence === Sequences.CdataEnd) {
                 this.cbs.oncdata(this.sectionStart, endIndex, 0);

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -1,6 +1,6 @@
 import {
     EntityDecoder,
-    EntityDecoderMode,
+    DecodingMode,
     htmlDecodeTree,
     xmlDecodeTree,
 } from "entities/lib/decode.js";
@@ -591,11 +591,11 @@ export default class Tokenizer {
         this.entityStart = this.index;
         this.entityDecoder.startEntity(
             this.xmlMode
-                ? EntityDecoderMode.Strict
+                ? DecodingMode.Strict
                 : this.baseState === State.Text ||
                   this.baseState === State.InSpecialTag
-                ? EntityDecoderMode.Text
-                : EntityDecoderMode.Attribute
+                ? DecodingMode.Legacy
+                : DecodingMode.Attribute
         );
     }
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -444,7 +444,6 @@ export default class Tokenizer {
         // Skip everything until ">"
         if (c === CharCodes.Gt || this.fastForwardTo(CharCodes.Gt)) {
             this.state = State.Text;
-            this.baseState = State.Text;
             this.sectionStart = this.index + 1;
         }
     }
@@ -457,7 +456,6 @@ export default class Tokenizer {
             } else {
                 this.state = State.Text;
             }
-            this.baseState = this.state;
             this.sectionStart = this.index + 1;
         } else if (c === CharCodes.Slash) {
             this.state = State.InSelfClosingTag;
@@ -470,7 +468,6 @@ export default class Tokenizer {
         if (c === CharCodes.Gt) {
             this.cbs.onselfclosingtag(this.index);
             this.state = State.Text;
-            this.baseState = State.Text;
             this.sectionStart = this.index + 1;
             this.isSpecial = false; // Reset special state, in case of self-closing special tags
         } else if (!isWhitespace(c)) {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -617,7 +617,10 @@ export default class Tokenizer {
     }
 
     private stateInEntity(): void {
-        const length = this.entityDecoder.write(this.buffer, this.index);
+        const length = this.entityDecoder.write(
+            this.buffer,
+            this.index - this.offset
+        );
 
         // If `length` is negative, we need to wait for more data.
         if (length >= 0) {
@@ -775,7 +778,8 @@ export default class Tokenizer {
 
     private finish() {
         if (this.state === State.InEntity) {
-            this.entityDecoder.end();
+            this.index += this.entityDecoder.end();
+            this.state = this.baseState;
         }
 
         // If there is remaining data, emit it in a reasonable way

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -626,6 +626,9 @@ export default class Tokenizer {
             if (length === 0) {
                 this.index = this.entityStart;
             }
+        } else {
+            // Mark buffer as consumed.
+            this.index = this.offset + this.buffer.length - 1;
         }
     }
 

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -227,54 +227,6 @@ exports[`Tokenizer should not lose data when pausing 1`] = `
 ]
 `;
 
-exports[`Tokenizer should support XML entities 1`] = `
-[
-  [
-    "ontextentity",
-    38,
-  ],
-  [
-    "ontextentity",
-    62,
-  ],
-  [
-    "ontext",
-    9,
-    13,
-  ],
-  [
-    "ontextentity",
-    60,
-  ],
-  [
-    "ontext",
-    17,
-    23,
-  ],
-  [
-    "ontextentity",
-    97,
-  ],
-  [
-    "ontext",
-    29,
-    34,
-  ],
-  [
-    "ontextentity",
-    99,
-  ],
-  [
-    "ontext",
-    39,
-    49,
-  ],
-  [
-    "onend",
-  ],
-]
-`;
-
 exports[`Tokenizer should support self-closing special tags for self-closing script tag 1`] = `
 [
   [

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -87,6 +87,54 @@ exports[`Tokenizer should not lose data when pausing 1`] = `
 ]
 `;
 
+exports[`Tokenizer should support XML entities 1`] = `
+[
+  [
+    "ontextentity",
+    38,
+  ],
+  [
+    "ontextentity",
+    62,
+  ],
+  [
+    "ontext",
+    9,
+    13,
+  ],
+  [
+    "ontextentity",
+    60,
+  ],
+  [
+    "ontext",
+    17,
+    23,
+  ],
+  [
+    "ontextentity",
+    97,
+  ],
+  [
+    "ontext",
+    29,
+    34,
+  ],
+  [
+    "ontextentity",
+    99,
+  ],
+  [
+    "ontext",
+    39,
+    49,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
 exports[`Tokenizer should support self-closing special tags for self-closing script tag 1`] = `
 [
   [

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -1,5 +1,145 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Tokenizer should handle entities for XML entities 1`] = `
+[
+  [
+    "ontextentity",
+    38,
+  ],
+  [
+    "ontextentity",
+    62,
+  ],
+  [
+    "ontext",
+    9,
+    13,
+  ],
+  [
+    "ontextentity",
+    60,
+  ],
+  [
+    "ontext",
+    17,
+    23,
+  ],
+  [
+    "ontextentity",
+    97,
+  ],
+  [
+    "ontext",
+    29,
+    34,
+  ],
+  [
+    "ontextentity",
+    99,
+  ],
+  [
+    "ontext",
+    39,
+    49,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
+exports[`Tokenizer should handle entities for entities in attributes (#276) 1`] = `
+[
+  [
+    "onopentagname",
+    1,
+    4,
+  ],
+  [
+    "onattribname",
+    5,
+    8,
+  ],
+  [
+    "onattribdata",
+    10,
+    24,
+  ],
+  [
+    "onattribentity",
+    8465,
+  ],
+  [
+    "onattribdata",
+    31,
+    41,
+  ],
+  [
+    "onattribend",
+    3,
+    41,
+  ],
+  [
+    "onselfclosingtag",
+    43,
+  ],
+  [
+    "ontext",
+    44,
+    58,
+  ],
+  [
+    "ontextentity",
+    8465,
+  ],
+  [
+    "ontext",
+    65,
+    75,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
+exports[`Tokenizer should handle entities for multi-byte entities 1`] = `
+[
+  [
+    "ontextentity",
+    8807,
+  ],
+  [
+    "ontextentity",
+    824,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
+exports[`Tokenizer should handle entities for trailing legacy entity 1`] = `
+[
+  [
+    "ontextentity",
+    10801,
+  ],
+  [
+    "ontextentity",
+    215,
+  ],
+  [
+    "ontext",
+    16,
+    19,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
 exports[`Tokenizer should not break after special tag followed by an entity for normal special tag 1`] = `
 [
   [

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -5,10 +5,12 @@ exports[`Tokenizer should handle entities for XML entities 1`] = `
   [
     "ontextentity",
     38,
+    5,
   ],
   [
     "ontextentity",
     62,
+    9,
   ],
   [
     "ontext",
@@ -18,6 +20,7 @@ exports[`Tokenizer should handle entities for XML entities 1`] = `
   [
     "ontextentity",
     60,
+    17,
   ],
   [
     "ontext",
@@ -27,6 +30,7 @@ exports[`Tokenizer should handle entities for XML entities 1`] = `
   [
     "ontextentity",
     97,
+    29,
   ],
   [
     "ontext",
@@ -36,6 +40,7 @@ exports[`Tokenizer should handle entities for XML entities 1`] = `
   [
     "ontextentity",
     99,
+    39,
   ],
   [
     "ontext",
@@ -91,6 +96,7 @@ exports[`Tokenizer should handle entities for entities in attributes (#276) 1`] 
   [
     "ontextentity",
     8465,
+    65,
   ],
   [
     "ontext",
@@ -108,10 +114,12 @@ exports[`Tokenizer should handle entities for multi-byte entities 1`] = `
   [
     "ontextentity",
     8807,
+    21,
   ],
   [
     "ontextentity",
     824,
+    21,
   ],
   [
     "onend",
@@ -124,10 +132,12 @@ exports[`Tokenizer should handle entities for trailing legacy entity 1`] = `
   [
     "ontextentity",
     10801,
+    10,
   ],
   [
     "ontextentity",
     215,
+    16,
   ],
   [
     "ontext",
@@ -164,6 +174,7 @@ exports[`Tokenizer should not break after special tag followed by an entity for 
   [
     "ontextentity",
     39,
+    24,
   ],
   [
     "onopentagname",
@@ -194,6 +205,7 @@ exports[`Tokenizer should not break after special tag followed by an entity for 
   [
     "ontextentity",
     39,
+    15,
   ],
   [
     "onopentagname",
@@ -215,6 +227,7 @@ exports[`Tokenizer should not lose data when pausing 1`] = `
   [
     "ontextentity",
     38,
+    5,
   ],
   [
     "ontext",


### PR DESCRIPTION
`entities` now features an `EntityDecoder` class that closely follows the HTML spec. We can use it here to improve entity parsing performance and accuracy.

The biggest change here is that `htmlparser2` now correctly handles named entities in attributes. `foo=bar&amp=baz` in an attribute will now be left as it is, following the expected behavior from the HTML spec.