### PR TITLE
Add customVoidElements as options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "htmlparser2",
     "description": "Fast & forgiving HTML/XML parser",
-    "version": "8.0.2",
+    "version": "8.0.3",
     "author": "Felix Boehm <me@feedic.com>",
     "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -153,6 +153,14 @@ export interface ParserOptions {
      * Allows the default tokenizer to be overwritten.
      */
     Tokenizer?: typeof Tokenizer;
+
+    /**
+     * If given a list of custom elements, the parser will treat them as void elements.
+     * This means that the parser will not expect them to have end tags.
+     * For example, if you pass `["custom"]` as a custom void element, then the following will be parsed as a single element:
+     * `<custom>text</custom>`.
+     */
+    customVoidElements?: Array<string>;
 }
 
 export interface Handler {
@@ -263,7 +271,11 @@ export class Parser implements Callbacks {
     }
 
     protected isVoidElement(name: string): boolean {
-        return !this.options.xmlMode && voidElements.has(name);
+        return (
+            !this.options.xmlMode &&
+            (this.options.customVoidElements?.includes(name) ||
+                voidElements.has(name))
+        );
     }
 
     /** @internal */

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ import { getFeed, Feed } from "domutils";
 
 export { getFeed } from "domutils";
 
-const parseFeedDefaultOptions = { xmlMode: true };
+const parseFeedDefaultOptions = { xmlMode: true, customVoidElements: [] };
 
 /**
  * Parse a feed.


### PR DESCRIPTION
Add support for custom elements that might have self closing tags.
We do this by extending options to accept `customVoidElements` which defaults to empty. 
The function `isVoidElements` now checks when parsing if a certain element exists in the `customVoidElements` in addition to the `voidElements` list