### PR TITLE
Fix Tokenizer onattribend's `endIndex`

### DIFF
--- a/src/Tokenizer.spec.ts
+++ b/src/Tokenizer.spec.ts
@@ -47,6 +47,21 @@ describe("Tokenizer", () => {
         });
     });
 
+    describe("should correctly mark attributes", () => {
+        it("for no value attribute", () => {
+            expect(tokenize("<div aaaaaaa >")).toMatchSnapshot();
+        });
+        it("for no quotes attribute", () => {
+            expect(tokenize("<div aaa=aaa >")).toMatchSnapshot();
+        });
+        it("for single quotes attribute", () => {
+            expect(tokenize("<div aaa='a' >")).toMatchSnapshot();
+        });
+        it("for double quotes attribute", () => {
+            expect(tokenize('<div aaa="a" >')).toMatchSnapshot();
+        });
+    });
+
     describe("should not break after special tag followed by an entity", () => {
         it("for normal special tag", () => {
             expect(tokenize("<style>a{}</style>&apos;<br/>")).toMatchSnapshot();

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -464,7 +464,7 @@ export default class Tokenizer {
     private stateInAttributeName(c: number): void {
         if (c === CharCodes.Eq || isEndOfTagSection(c)) {
             this.cbs.onattribname(this.sectionStart, this.index);
-            this.sectionStart = -1;
+            this.sectionStart = this.index;
             this.state = State.AfterAttributeName;
             this.stateAfterAttributeName(c);
         }
@@ -473,11 +473,12 @@ export default class Tokenizer {
         if (c === CharCodes.Eq) {
             this.state = State.BeforeAttributeValue;
         } else if (c === CharCodes.Slash || c === CharCodes.Gt) {
-            this.cbs.onattribend(QuoteType.NoValue, this.index);
+            this.cbs.onattribend(QuoteType.NoValue, this.sectionStart);
+            this.sectionStart = -1;
             this.state = State.BeforeAttributeName;
             this.stateBeforeAttributeName(c);
         } else if (!isWhitespace(c)) {
-            this.cbs.onattribend(QuoteType.NoValue, this.index);
+            this.cbs.onattribend(QuoteType.NoValue, this.sectionStart);
             this.state = State.InAttributeName;
             this.sectionStart = this.index;
         }
@@ -506,7 +507,7 @@ export default class Tokenizer {
                 quote === CharCodes.DoubleQuote
                     ? QuoteType.Double
                     : QuoteType.Single,
-                this.index
+                this.index + 1
             );
             this.state = State.BeforeAttributeName;
         } else if (this.decodeEntities && c === CharCodes.Amp) {

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -1,5 +1,128 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Tokenizer should correctly mark attributes for double quotes attribute 1`] = `
+[
+  [
+    "onopentagname",
+    1,
+    4,
+  ],
+  [
+    "onattribname",
+    5,
+    8,
+  ],
+  [
+    "onattribdata",
+    10,
+    11,
+  ],
+  [
+    "onattribend",
+    3,
+    12,
+  ],
+  [
+    "onopentagend",
+    13,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
+exports[`Tokenizer should correctly mark attributes for no quotes attribute 1`] = `
+[
+  [
+    "onopentagname",
+    1,
+    4,
+  ],
+  [
+    "onattribname",
+    5,
+    8,
+  ],
+  [
+    "onattribdata",
+    9,
+    12,
+  ],
+  [
+    "onattribend",
+    1,
+    12,
+  ],
+  [
+    "onopentagend",
+    13,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
+exports[`Tokenizer should correctly mark attributes for no value attribute 1`] = `
+[
+  [
+    "onopentagname",
+    1,
+    4,
+  ],
+  [
+    "onattribname",
+    5,
+    12,
+  ],
+  [
+    "onattribend",
+    0,
+    12,
+  ],
+  [
+    "onopentagend",
+    13,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
+exports[`Tokenizer should correctly mark attributes for single quotes attribute 1`] = `
+[
+  [
+    "onopentagname",
+    1,
+    4,
+  ],
+  [
+    "onattribname",
+    5,
+    8,
+  ],
+  [
+    "onattribdata",
+    10,
+    11,
+  ],
+  [
+    "onattribend",
+    2,
+    12,
+  ],
+  [
+    "onopentagend",
+    13,
+  ],
+  [
+    "onend",
+  ],
+]
+`;
+
 exports[`Tokenizer should handle entities for XML entities 1`] = `
 [
   [

--- a/src/__snapshots__/Tokenizer.spec.ts.snap
+++ b/src/__snapshots__/Tokenizer.spec.ts.snap
@@ -205,7 +205,7 @@ exports[`Tokenizer should handle entities for entities in attributes (#276) 1`] 
   [
     "onattribend",
     3,
-    41,
+    42,
   ],
   [
     "onselfclosingtag",

--- a/src/__snapshots__/WritableStream.spec.ts.snap
+++ b/src/__snapshots__/WritableStream.spec.ts.snap
@@ -58,7 +58,7 @@ exports[`WritableStream Atom feed 1`] = `
       "http://www.w3.org/2005/Atom",
       """,
     ],
-    "endIndex": 137,
+    "endIndex": 138,
     "startIndex": 103,
   },
   {
@@ -185,7 +185,7 @@ exports[`WritableStream Atom feed 1`] = `
       "http://example.org/feed/",
       """,
     ],
-    "endIndex": 240,
+    "endIndex": 241,
     "startIndex": 210,
   },
   {
@@ -195,7 +195,7 @@ exports[`WritableStream Atom feed 1`] = `
       "self",
       """,
     ],
-    "endIndex": 251,
+    "endIndex": 252,
     "startIndex": 242,
   },
   {
@@ -244,7 +244,7 @@ exports[`WritableStream Atom feed 1`] = `
       "http://example.org/",
       """,
     ],
-    "endIndex": 288,
+    "endIndex": 289,
     "startIndex": 263,
   },
   {
@@ -585,7 +585,7 @@ exports[`WritableStream Atom feed 1`] = `
       "http://example.org/2003/12/13/atom03",
       """,
     ],
-    "endIndex": 578,
+    "endIndex": 579,
     "startIndex": 536,
   },
   {
@@ -633,7 +633,7 @@ exports[`WritableStream Atom feed 1`] = `
       "alternate",
       """,
     ],
-    "endIndex": 605,
+    "endIndex": 606,
     "startIndex": 591,
   },
   {
@@ -643,7 +643,7 @@ exports[`WritableStream Atom feed 1`] = `
       "text/html",
       """,
     ],
-    "endIndex": 622,
+    "endIndex": 623,
     "startIndex": 607,
   },
   {
@@ -653,7 +653,7 @@ exports[`WritableStream Atom feed 1`] = `
       "http://example.org/2003/12/13/atom03.html",
       """,
     ],
-    "endIndex": 671,
+    "endIndex": 672,
     "startIndex": 624,
   },
   {
@@ -703,7 +703,7 @@ exports[`WritableStream Atom feed 1`] = `
       "edit",
       """,
     ],
-    "endIndex": 692,
+    "endIndex": 693,
     "startIndex": 683,
   },
   {
@@ -713,7 +713,7 @@ exports[`WritableStream Atom feed 1`] = `
       "http://example.org/2003/12/13/atom03/edit",
       """,
     ],
-    "endIndex": 741,
+    "endIndex": 742,
     "startIndex": 694,
   },
   {
@@ -850,7 +850,7 @@ exports[`WritableStream Atom feed 1`] = `
       "html",
       """,
     ],
-    "endIndex": 865,
+    "endIndex": 866,
     "startIndex": 855,
   },
   {
@@ -1196,7 +1196,7 @@ exports[`WritableStream Attributes 1`] = `
       "test0",
       """,
     ],
-    "endIndex": 123,
+    "endIndex": 124,
     "startIndex": 114,
   },
   {
@@ -1206,7 +1206,7 @@ exports[`WritableStream Attributes 1`] = `
       "value0",
       """,
     ],
-    "endIndex": 138,
+    "endIndex": 139,
     "startIndex": 125,
   },
   {
@@ -1216,7 +1216,7 @@ exports[`WritableStream Attributes 1`] = `
       "value1",
       """,
     ],
-    "endIndex": 153,
+    "endIndex": 154,
     "startIndex": 140,
   },
   {
@@ -1298,7 +1298,7 @@ exports[`WritableStream Attributes 1`] = `
       "test1",
       """,
     ],
-    "endIndex": 258,
+    "endIndex": 259,
     "startIndex": 249,
   },
   {
@@ -1399,7 +1399,7 @@ exports[`WritableStream Attributes 1`] = `
       "test2",
       """,
     ],
-    "endIndex": 419,
+    "endIndex": 420,
     "startIndex": 410,
   },
   {
@@ -1409,7 +1409,7 @@ exports[`WritableStream Attributes 1`] = `
       "value4",
       """,
     ],
-    "endIndex": 434,
+    "endIndex": 435,
     "startIndex": 421,
   },
   {
@@ -1419,7 +1419,7 @@ exports[`WritableStream Attributes 1`] = `
       "value5",
       """,
     ],
-    "endIndex": 448,
+    "endIndex": 449,
     "startIndex": 435,
   },
   {
@@ -1638,7 +1638,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
       """,
     ],
-    "endIndex": 102,
+    "endIndex": 103,
     "startIndex": 48,
   },
   {
@@ -1648,7 +1648,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://purl.org/rss/1.0/",
       """,
     ],
-    "endIndex": 135,
+    "endIndex": 136,
     "startIndex": 104,
   },
   {
@@ -1658,7 +1658,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://purl.org/rss/1.0/modules/event/",
       """,
     ],
-    "endIndex": 185,
+    "endIndex": 186,
     "startIndex": 137,
   },
   {
@@ -1668,7 +1668,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://purl.org/rss/1.0/modules/content/",
       """,
     ],
-    "endIndex": 242,
+    "endIndex": 243,
     "startIndex": 187,
   },
   {
@@ -1678,7 +1678,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://purl.org/rss/1.0/modules/taxonomy/",
       """,
     ],
-    "endIndex": 297,
+    "endIndex": 298,
     "startIndex": 244,
   },
   {
@@ -1688,7 +1688,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://purl.org/dc/elements/1.1/",
       """,
     ],
-    "endIndex": 341,
+    "endIndex": 342,
     "startIndex": 299,
   },
   {
@@ -1698,7 +1698,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://purl.org/rss/1.0/modules/syndication/",
       """,
     ],
-    "endIndex": 398,
+    "endIndex": 399,
     "startIndex": 343,
   },
   {
@@ -1708,7 +1708,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://purl.org/dc/terms/",
       """,
     ],
-    "endIndex": 440,
+    "endIndex": 441,
     "startIndex": 400,
   },
   {
@@ -1718,7 +1718,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://webns.net/mvcb/",
       """,
     ],
-    "endIndex": 477,
+    "endIndex": 478,
     "startIndex": 442,
   },
   {
@@ -1765,7 +1765,7 @@ exports[`WritableStream RDF feed 1`] = `
       "https://github.com/fb55/htmlparser2/",
       """,
     ],
-    "endIndex": 537,
+    "endIndex": 538,
     "startIndex": 490,
   },
   {
@@ -2422,7 +2422,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://somefakesite/path/to/something.html",
       """,
     ],
-    "endIndex": 1251,
+    "endIndex": 1252,
     "startIndex": 1195,
   },
   {
@@ -2524,7 +2524,7 @@ exports[`WritableStream RDF feed 1`] = `
       "http://somefakesite/path/to/something.html",
       """,
     ],
-    "endIndex": 1352,
+    "endIndex": 1353,
     "startIndex": 1299,
   },
   {
@@ -3063,7 +3063,7 @@ http://somefakesite/path/to/something.html
       "http://somefakesite/path/to/something-else.html",
       """,
     ],
-    "endIndex": 1996,
+    "endIndex": 1997,
     "startIndex": 1938,
   },
   {
@@ -3661,7 +3661,7 @@ exports[`WritableStream RSS feed 1`] = `
       "2.0",
       """,
     ],
-    "endIndex": 105,
+    "endIndex": 106,
     "startIndex": 93,
   },
   {
@@ -5127,7 +5127,7 @@ exports[`WritableStream RSS feed 1`] = `
       "200",
       """,
     ],
-    "endIndex": 2601,
+    "endIndex": 2602,
     "startIndex": 2590,
   },
   {
@@ -5137,7 +5137,7 @@ exports[`WritableStream RSS feed 1`] = `
       "image",
       """,
     ],
-    "endIndex": 2616,
+    "endIndex": 2617,
     "startIndex": 2603,
   },
   {
@@ -5147,7 +5147,7 @@ exports[`WritableStream RSS feed 1`] = `
       "https://picsum.photos/200",
       """,
     ],
-    "endIndex": 2648,
+    "endIndex": 2649,
     "startIndex": 2618,
   },
   {
@@ -5157,7 +5157,7 @@ exports[`WritableStream RSS feed 1`] = `
       "200",
       """,
     ],
-    "endIndex": 2660,
+    "endIndex": 2661,
     "startIndex": 2650,
   },
   {
@@ -5419,7 +5419,7 @@ exports[`WritableStream SVG 1`] = `
       "1.1",
       """,
     ],
-    "endIndex": 88,
+    "endIndex": 89,
     "startIndex": 76,
   },
   {
@@ -5429,7 +5429,7 @@ exports[`WritableStream SVG 1`] = `
       "http://www.w3.org/2000/svg",
       """,
     ],
-    "endIndex": 123,
+    "endIndex": 124,
     "startIndex": 90,
   },
   {
@@ -5439,7 +5439,7 @@ exports[`WritableStream SVG 1`] = `
       "http://www.w3.org/1999/xlink",
       """,
     ],
-    "endIndex": 166,
+    "endIndex": 167,
     "startIndex": 125,
   },
   {

--- a/src/__tests__/__snapshots__/events.ts.snap
+++ b/src/__tests__/__snapshots__/events.ts.snap
@@ -57,7 +57,7 @@ exports[`Events Attribute in XML (see #1350) 1`] = `
       "Hello world",
       """,
     ],
-    "endIndex": 28,
+    "endIndex": 29,
     "startIndex": 10,
   },
   {
@@ -67,7 +67,7 @@ exports[`Events Attribute in XML (see #1350) 1`] = `
       "false",
       """,
     ],
-    "endIndex": 57,
+    "endIndex": 58,
     "startIndex": 34,
   },
   {
@@ -395,7 +395,7 @@ exports[`Events Entities in attributes 1`] = `
       "&",
       """,
     ],
-    "endIndex": 25,
+    "endIndex": 26,
     "startIndex": 15,
   },
   {
@@ -405,7 +405,7 @@ exports[`Events Entities in attributes 1`] = `
       "&",
       "'",
     ],
-    "endIndex": 37,
+    "endIndex": 38,
     "startIndex": 27,
   },
   {
@@ -1444,7 +1444,7 @@ exports[`Events Long comment ending 1`] = `
       "before",
       "'",
     ],
-    "endIndex": 16,
+    "endIndex": 17,
     "startIndex": 6,
   },
   {
@@ -1497,7 +1497,7 @@ exports[`Events Long comment ending 1`] = `
       "after",
       "'",
     ],
-    "endIndex": 47,
+    "endIndex": 48,
     "startIndex": 38,
   },
   {
@@ -2254,7 +2254,7 @@ exports[`Events Start & end indices from domhandler 1`] = `
       "foo",
       "'",
     ],
-    "endIndex": 64,
+    "endIndex": 65,
     "startIndex": 54,
   },
   {
@@ -2398,7 +2398,7 @@ exports[`Events Template script tags 1`] = `
       "text/template",
       """,
     ],
-    "endIndex": 30,
+    "endIndex": 31,
     "startIndex": 11,
   },
   {
@@ -2544,7 +2544,7 @@ exports[`Events attributes (no white space, no value, no quotes) 1`] = `
       "test0",
       """,
     ],
-    "endIndex": 20,
+    "endIndex": 21,
     "startIndex": 8,
   },
   {
@@ -2554,7 +2554,7 @@ exports[`Events attributes (no white space, no value, no quotes) 1`] = `
       "test1",
       """,
     ],
-    "endIndex": 33,
+    "endIndex": 34,
     "startIndex": 21,
   },
   {
@@ -2563,7 +2563,7 @@ exports[`Events attributes (no white space, no value, no quotes) 1`] = `
       "disabled",
       "",
     ],
-    "endIndex": 44,
+    "endIndex": 43,
     "startIndex": 35,
   },
   {
@@ -2628,7 +2628,7 @@ exports[`Events crazy attribute 1`] = `
       "",
       "'",
     ],
-    "endIndex": 8,
+    "endIndex": 9,
     "startIndex": 3,
   },
   {
@@ -3360,7 +3360,7 @@ exports[`Events entity in attribute (#276) 1`] = `
       "?&image_uri=1&ℑ=2&image=3",
       """,
     ],
-    "endIndex": 41,
+    "endIndex": 42,
     "startIndex": 5,
   },
   {
@@ -3412,7 +3412,7 @@ exports[`Events entity in attribute 1`] = `
       "http://example.com/pa#x61ge?param=value&param2&param3=<val&; & &",
       "'",
     ],
-    "endIndex": 81,
+    "endIndex": 82,
     "startIndex": 3,
   },
   {


### PR DESCRIPTION
Fixes https://github.com/fb55/htmlparser2/issues/1538

1. For `NoValue` attributes `endIndex` is set to attribute name's end index
2. For attributes with quotes `endIndex` moved one character forward to match actual attribute end

Output of the script from the ticket:
```
<a aaaaa   >
        ^
Attribute endIndex: 8

<a aaaaa >
        ^
Attribute endIndex: 8

<a a=aaa >
        ^
Attribute endIndex: 8

<a a="a" >
        ^
Attribute endIndex: 8
```

The fix makes `endIndex` consistent, however I'm a little bit worried that change for quoted attributes may be breaking for someone.