### PR TITLE
feat(Parser): exports Handler interface from Parser

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -68,6 +68,11 @@
                 "@typescript-eslint/no-unnecessary-condition": 2,
                 "@typescript-eslint/switch-exhaustiveness-check": 2,
                 "@typescript-eslint/prefer-nullish-coalescing": 2,
+                "@typescript-eslint/consistent-type-imports": [
+                    2,
+                    { "fixStyle": "inline-type-imports" }
+                ],
+                "@typescript-eslint/consistent-type-exports": 2,
 
                 "n/no-unsupported-features/es-syntax": 0
             }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,4 +1,4 @@
-import Tokenizer, { Callbacks, QuoteType } from "./Tokenizer.js";
+import Tokenizer, { type Callbacks, QuoteType } from "./Tokenizer.js";
 import { fromCodePoint } from "entities/lib/decode.js";
 
 const formTags = new Set([

--- a/src/WritableStream.ts
+++ b/src/WritableStream.ts
@@ -1,4 +1,4 @@
-import { Parser, Handler, ParserOptions } from "./Parser.js";
+import { Parser, type Handler, type ParserOptions } from "./Parser.js";
 /*
  * NOTE: If either of these two imports produces a type error,
  * please update your @types/node dependency!

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Parser, ParserOptions } from "./Parser.js";
-export { Parser, type ParserOptions } from "./Parser.js";
+export { Handler, Parser, type ParserOptions } from "./Parser.js";
 
 import {
     DomHandler,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
-import { Parser, ParserOptions } from "./Parser.js";
-export { Handler, Parser, type ParserOptions } from "./Parser.js";
+import { Parser, type ParserOptions } from "./Parser.js";
+export type { Handler, ParserOptions } from "./Parser.js";
+export { Parser } from "./Parser.js";
 
 import {
     DomHandler,
-    DomHandlerOptions,
-    ChildNode,
-    Element,
-    Document,
+    type DomHandlerOptions,
+    type ChildNode,
+    type Element,
+    type Document,
 } from "domhandler";
 
 export {


### PR DESCRIPTION
exports the `Handler` interface so consumers who implement typesafe Handlers don't need to do something along the lines of this:

```ts
import type { Parser } from 'htmlparser2';

type Handler = NonNullable<ConstructorParameters<typeof Parser>[0]>;
```