### PR TITLE
build: remove published test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     "files": [
         "WritableStream.js",
         "dist",
-        "src"
+        "src",
+        "!src/*.spec.ts",
+        "!src/__fixtures__",
+        "!src/__snapshots__"
     ],
     "scripts": {
         "build": "tshy",


### PR DESCRIPTION
It looks like `tshy.exclude` only excludes processing into `dist`, but `npm publish` and `npm pack` would still pack the test files in `src`.