### PR TITLE
fix: add td to th's implicit close set

### DIFF
--- a/src/Parser.spec.ts
+++ b/src/Parser.spec.ts
@@ -179,6 +179,25 @@ describe("API", () => {
         p.write("<__proto__>");
     });
 
+    it("should implicitly close <td> when <th> opens", () => {
+        const onclosetag = vi.fn();
+        const onopentagname = vi.fn();
+
+        new Parser({ onclosetag, onopentagname }).end(
+            "<table><tr><td>A<th>B</tr></table>",
+        );
+
+        // <th> must auto-close <td>, making them siblings per the HTML spec
+        expect(onclosetag).toHaveBeenCalledWith("td", true);
+        const tdClose = onclosetag.mock.calls.findIndex(
+            ([name]: [string]) => name === "td",
+        );
+        const thOpen = onopentagname.mock.calls.findIndex(
+            ([name]: [string]) => name === "th",
+        );
+        expect(tdClose).toBeLessThan(thOpen);
+    });
+
     it("should support custom tokenizer", () => {
         class CustomTokenizer extends Tokenizer {}
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -19,7 +19,7 @@ const rtpTags = new Set(["rt", "rp"]);
 
 const openImpliesClose = new Map<string, Set<string>>([
     ["tr", new Set(["tr", "th", "td"])],
-    ["th", new Set(["th"])],
+    ["th", new Set(["th", "td"])],
     ["td", new Set(["thead", "th", "td"])],
     ["body", new Set(["head", "link", "script"])],
     ["a", new Set(["a"])],


### PR DESCRIPTION
Opening a `<th>` should auto-close an open `<td>`, but it doesn't. The `openImpliesClose` entry for `th` only includes `["th"]`, so a `<td>` is never implicitly closed when `<th>` opens. This causes `<th>` to incorrectly become a child of `<td>` instead of a sibling.

The HTML spec's optional tag rules are symmetric here. A `<td>` end tag can be omitted when followed by a `<td>` or `<th>`, and a `<th>` end tag can be omitted when followed by a `<td>` or `<th>`. The `td` entry already handles this correctly with `["thead", "th", "td"]`, but the `th` entry was missing `"td"`.

Verified by comparing htmlparser2 output against parse5 (spec-compliant parser). For `<table><tr><td>A<th>B</tr></table>`:

- **Before:** `<th>` is nested inside `<td>` (wrong)
- **After:** `<td>` and `<th>` are siblings under `<tr>` (matches spec and browsers)

Ref: https://html.spec.whatwg.org/multipage/syntax.html#optional-tags