### PR TITLE
fix: table section tags should implicitly close other table sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "eslint-config-biome": "^2.1.3",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.57.1",
-                "vitest": "^4.1.0"
+                "vitest": "^4.1.1"
             },
             "engines": {
                 "node": ">=20.19.0"
@@ -216,24 +216,26 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-            "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.0",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-            "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+            "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -245,6 +247,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -491,36 +494,28 @@
             "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+            "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
                 "@tybys/wasm-util": "^0.10.1"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
-        "node_modules/@oxc-project/runtime": {
-            "version": "0.115.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
-            "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.115.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
-            "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+            "version": "0.122.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -528,9 +523,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
             "cpu": [
                 "arm64"
             ],
@@ -545,9 +540,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
             "cpu": [
                 "arm64"
             ],
@@ -562,9 +557,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
             "cpu": [
                 "x64"
             ],
@@ -579,9 +574,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
             "cpu": [
                 "x64"
             ],
@@ -596,9 +591,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
-            "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+            "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
             "cpu": [
                 "arm"
             ],
@@ -613,9 +608,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
             "cpu": [
                 "arm64"
             ],
@@ -630,9 +625,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
-            "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
             "cpu": [
                 "arm64"
             ],
@@ -647,9 +642,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
             "cpu": [
                 "ppc64"
             ],
@@ -664,9 +659,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
             "cpu": [
                 "s390x"
             ],
@@ -681,9 +676,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
             "cpu": [
                 "x64"
             ],
@@ -698,9 +693,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
-            "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
             "cpu": [
                 "x64"
             ],
@@ -715,9 +710,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
             "cpu": [
                 "arm64"
             ],
@@ -732,9 +727,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
-            "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
             "cpu": [
                 "wasm32"
             ],
@@ -749,9 +744,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
-            "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -766,9 +761,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
-            "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
             "cpu": [
                 "x64"
             ],
@@ -783,9 +778,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
-            "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+            "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1100,16 +1095,16 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
-            "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+            "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.0",
-                "@vitest/utils": "4.1.0",
+                "@vitest/spy": "4.1.1",
+                "@vitest/utils": "4.1.1",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.0.3"
             },
@@ -1118,13 +1113,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
-            "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+            "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.0",
+                "@vitest/spy": "4.1.1",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -1133,7 +1128,7 @@
             },
             "peerDependencies": {
                 "msw": "^2.4.9",
-                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "msw": {
@@ -1145,9 +1140,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
-            "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+            "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1158,13 +1153,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
-            "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+            "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.0",
+                "@vitest/utils": "4.1.1",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1172,14 +1167,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
-            "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+            "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.0",
-                "@vitest/utils": "4.1.0",
+                "@vitest/pretty-format": "4.1.1",
+                "@vitest/utils": "4.1.1",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -1188,9 +1183,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
-            "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+            "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1198,13 +1193,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
-            "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+            "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.0",
+                "@vitest/pretty-format": "4.1.1",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.0.3"
             },
@@ -2902,9 +2897,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3020,14 +3015,14 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
-            "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+            "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.115.0",
-                "@rolldown/pluginutils": "1.0.0-rc.9"
+                "@oxc-project/types": "=0.122.0",
+                "@rolldown/pluginutils": "1.0.0-rc.12"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -3036,21 +3031,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.9",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
             }
         },
         "node_modules/semver": {
@@ -3460,17 +3455,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
-            "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+            "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "0.115.0",
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.3",
+                "picomatch": "^4.0.4",
                 "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.9",
+                "rolldown": "1.0.0-rc.12",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -3487,7 +3481,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.0.0-alpha.31",
+                "@vitejs/devtools": "^0.1.0",
                 "esbuild": "^0.27.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -3539,19 +3533,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
-            "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+            "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.0",
-                "@vitest/mocker": "4.1.0",
-                "@vitest/pretty-format": "4.1.0",
-                "@vitest/runner": "4.1.0",
-                "@vitest/snapshot": "4.1.0",
-                "@vitest/spy": "4.1.0",
-                "@vitest/utils": "4.1.0",
+                "@vitest/expect": "4.1.1",
+                "@vitest/mocker": "4.1.1",
+                "@vitest/pretty-format": "4.1.1",
+                "@vitest/runner": "4.1.1",
+                "@vitest/snapshot": "4.1.1",
+                "@vitest/spy": "4.1.1",
+                "@vitest/utils": "4.1.1",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -3563,7 +3557,7 @@
                 "tinyexec": "^1.0.2",
                 "tinyglobby": "^0.2.15",
                 "tinyrainbow": "^3.0.3",
-                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
@@ -3579,13 +3573,13 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.0",
-                "@vitest/browser-preview": "4.1.0",
-                "@vitest/browser-webdriverio": "4.1.0",
-                "@vitest/ui": "4.1.0",
+                "@vitest/browser-playwright": "4.1.1",
+                "@vitest/browser-preview": "4.1.1",
+                "@vitest/browser-webdriverio": "4.1.1",
+                "@vitest/ui": "4.1.1",
                 "happy-dom": "*",
                 "jsdom": "*",
-                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "eslint-config-biome": "^2.1.3",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.1",
-        "vitest": "^4.1.0"
+        "vitest": "^4.1.1"
     },
     "engines": {
         "node": ">=20.19.0"

--- a/src/Parser.spec.ts
+++ b/src/Parser.spec.ts
@@ -179,6 +179,43 @@ describe("API", () => {
         p.write("<__proto__>");
     });
 
+    it("should implicitly close table sections when another section opens", () => {
+        const onopentagname = vi.fn();
+        const onclosetag = vi.fn();
+
+        // <tbody> must auto-close <tfoot>
+        new Parser({ onopentagname, onclosetag }).end(
+            "<table><tfoot><tr><td>F<tbody><tr><td>B</table>",
+        );
+
+        expect(onclosetag).toHaveBeenCalledWith("tfoot", true);
+        const tfootClose = onclosetag.mock.calls.findIndex(
+            ([name]: [string]) => name === "tfoot",
+        );
+        const tbodyOpen = onopentagname.mock.calls.findIndex(
+            ([name]: [string]) => name === "tbody",
+        );
+        expect(tfootClose).toBeLessThan(tbodyOpen);
+    });
+
+    it("should implicitly close <tbody> when <thead> opens", () => {
+        const onopentagname = vi.fn();
+        const onclosetag = vi.fn();
+
+        new Parser({ onopentagname, onclosetag }).end(
+            "<table><tbody><tr><td>B<thead><tr><th>H</table>",
+        );
+
+        expect(onclosetag).toHaveBeenCalledWith("tbody", true);
+        const tbodyClose = onclosetag.mock.calls.findIndex(
+            ([name]: [string]) => name === "tbody",
+        );
+        const theadOpen = onopentagname.mock.calls.findIndex(
+            ([name]: [string]) => name === "thead",
+        );
+        expect(tbodyClose).toBeLessThan(theadOpen);
+    });
+
     it("should support custom tokenizer", () => {
         class CustomTokenizer extends Tokenizer {}
 

--- a/src/Parser.spec.ts
+++ b/src/Parser.spec.ts
@@ -190,10 +190,10 @@ describe("API", () => {
 
         expect(onclosetag).toHaveBeenCalledWith("tfoot", true);
         const tfootClose = onclosetag.mock.calls.findIndex(
-            ([name]: [string]) => name === "tfoot",
+            ([name]) => name === "tfoot",
         );
         const tbodyOpen = onopentagname.mock.calls.findIndex(
-            ([name]: [string]) => name === "tbody",
+            ([name]) => name === "tbody",
         );
         expect(tfootClose).toBeLessThan(tbodyOpen);
     });
@@ -208,10 +208,10 @@ describe("API", () => {
 
         expect(onclosetag).toHaveBeenCalledWith("tbody", true);
         const tbodyClose = onclosetag.mock.calls.findIndex(
-            ([name]: [string]) => name === "tbody",
+            ([name]) => name === "tbody",
         );
         const theadOpen = onopentagname.mock.calls.findIndex(
-            ([name]: [string]) => name === "thead",
+            ([name]) => name === "thead",
         );
         expect(tbodyClose).toBeLessThan(theadOpen);
     });
@@ -227,10 +227,10 @@ describe("API", () => {
         // <th> must auto-close <td>, making them siblings per the HTML spec
         expect(onclosetag).toHaveBeenCalledWith("td", true);
         const tdClose = onclosetag.mock.calls.findIndex(
-            ([name]: [string]) => name === "td",
+            ([name]) => name === "td",
         );
         const thOpen = onopentagname.mock.calls.findIndex(
-            ([name]: [string]) => name === "th",
+            ([name]) => name === "th",
         );
         expect(tdClose).toBeLessThan(thOpen);
     });

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -13,7 +13,7 @@ const formTags = new Set([
 ]);
 const pTag = new Set(["p"]);
 const headingTags = new Set(["h1", "h2", "h3", "h4", "h5", "h6", "p"]);
-const tableSectionTags = new Set(["thead", "tbody"]);
+const tableSectionTags = new Set(["thead", "tbody", "tfoot", "tr", "td", "th"]);
 const ddtTags = new Set(["dd", "dt"]);
 const rtpTags = new Set(["rt", "rp"]);
 
@@ -64,6 +64,7 @@ const openImpliesClose = new Map<string, Set<string>>([
     ["ul", pTag],
     ["rt", rtpTags],
     ["rp", rtpTags],
+    ["thead", tableSectionTags],
     ["tbody", tableSectionTags],
     ["tfoot", tableSectionTags],
 ]);


### PR DESCRIPTION
Opening a `<thead>`, `<tbody>`, or `<tfoot>` should auto-close any currently open table section. This wasn't working for two reasons:

1. `<tfoot>` was missing from `tableSectionTags`, so `<tbody>` after `<tfoot>` (or `<tfoot>` after `<tfoot>`) would nest instead of being siblings.
2. `<thead>` had no entry in the `openImpliesClose` map at all, so `<thead>` after `<tbody>` would also nest incorrectly.

On top of that, the set also needed `tr`, `td`, and `th` because those elements sit above the section tag on the stack. The `openImpliesClose` mechanism only peels from the top, so it needs to be able to close through the row and cell elements to reach the section tag underneath.

For `<table><tfoot><tr><td>F<tbody><tr><td>B</table>`:

- **Before:** `<tbody>` nested inside `<tfoot>` > `<tr>` > `<td>`
- **After:** `<tfoot>` and `<tbody>` are siblings under `<table>`, matching browser/spec behavior

Verified against parse5 (spec-compliant reference parser) for all combinations of section tag ordering.

Ref: https://html.spec.whatwg.org/multipage/syntax.html#optional-tags