### PR TITLE
chore: use HTTPS repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git://github.com/fb55/htmlparser2.git"
+        "url": "https://github.com/fb55/htmlparser2.git"
     },
     "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",


### PR DESCRIPTION
Updates the package repository metadata to use HTTPS instead of the unauthenticated `git://` protocol.

Validation:
- `git diff --check`
- parsed the changed `package.json` file(s) with Node.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->