### PR TITLE
fix(tokenizer): treat `<![CDATA[` as a bogus comment in HTML mode

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -201,6 +201,7 @@ export default class Tokenizer {
     private readonly xmlMode: boolean;
     private readonly decodeEntities: boolean;
     private readonly recognizeSelfClosing: boolean;
+    private readonly recognizeCDATA: boolean;
     private readonly entityDecoder: EntityDecoder;
 
     constructor(
@@ -208,16 +209,19 @@ export default class Tokenizer {
             xmlMode = false,
             decodeEntities = true,
             recognizeSelfClosing = xmlMode,
+            recognizeCDATA = false,
         }: {
             xmlMode?: boolean;
             decodeEntities?: boolean;
             recognizeSelfClosing?: boolean;
+            recognizeCDATA?: boolean;
         },
         private readonly cbs: Callbacks,
     ) {
         this.xmlMode = xmlMode;
         this.decodeEntities = decodeEntities;
         this.recognizeSelfClosing = recognizeSelfClosing;
+        this.recognizeCDATA = recognizeCDATA;
         this.entityDecoder = new EntityDecoder(
             xmlMode ? xmlDecodeTree : htmlDecodeTree,
             (cp, consumed) => this.emitCodePoint(cp, consumed),
@@ -354,10 +358,19 @@ export default class Tokenizer {
     private stateCDATASequence(c: number): void {
         if (c === Sequences.Cdata[this.sequenceIndex]) {
             if (++this.sequenceIndex === Sequences.Cdata.length) {
-                this.state = State.InCommentLike;
-                this.currentSequence = Sequences.CdataEnd;
                 this.sequenceIndex = 0;
-                this.sectionStart = this.index + 1;
+                if (this.shouldRecognizeCDATA()) {
+                    this.state = State.InCommentLike;
+                    this.currentSequence = Sequences.CdataEnd;
+                    this.sectionStart = this.index + 1;
+                } else {
+                    /*
+                     * Outside XML / foreign content `<![CDATA[` is a bogus
+                     * comment that ends at the first `>`, per WHATWG HTML
+                     * §13.2.5.42/§13.2.5.43, leaving following markup live.
+                     */
+                    this.state = State.InSpecialComment;
+                }
             }
         } else {
             this.sequenceIndex = 0;
@@ -369,6 +382,14 @@ export default class Tokenizer {
                 this.stateInSpecialComment(c); // Reconsume the character
             }
         }
+    }
+
+    private shouldRecognizeCDATA(): boolean {
+        return (
+            this.xmlMode ||
+            this.recognizeCDATA ||
+            (this.cbs.isInForeignContext?.() ?? false)
+        );
     }
 
     /**

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -31,6 +31,52 @@ describe("Index", () => {
         expect(dom).toMatchSnapshot();
     });
 
+    /*
+     * In HTML mode, `<![CDATA[` outside foreign content is a bogus comment that
+     * ends at the first `>` (WHATWG HTML §13.2.5.42/§13.2.5.43), so the markup
+     * after `>` stays live. parse5 and every browser produce the comment plus a
+     * live `<img>`; htmlparser2 used to swallow it all into one comment.
+     */
+    it("treats `<![CDATA[` in HTML mode as a bogus comment ending at `>`", () => {
+        const dom = parseDocument("<![CDATA[x><img src=x onerror=alert(1)>");
+
+        expect(dom.children).toHaveLength(2);
+
+        const [comment, img] = dom.children;
+        expect(comment.type).toBe("comment");
+        expect((comment as { data: string }).data).toBe("[CDATA[x");
+
+        expect(img.type).toBe("tag");
+        expect((img as Element).name).toBe("img");
+        expect((img as Element).attribs).toEqual({
+            src: "x",
+            onerror: "alert(1)",
+        });
+    });
+
+    it("keeps real CDATA in foreign content (regression guard)", () => {
+        const dom = parseDocument("<svg><![CDATA[a<b]]></svg>");
+        const svg = dom.children[0] as Element;
+        expect(svg.name).toBe("svg");
+        expect(svg.children).toHaveLength(1);
+        const text = svg.children[0];
+        expect(text.type).toBe("text");
+        expect((text as { data: string }).data).toBe("a<b");
+    });
+
+    it("keeps real CDATA in xmlMode (regression guard)", () => {
+        const dom = parseDocument("<root><![CDATA[a<b]]></root>", {
+            xmlMode: true,
+        });
+        const root = dom.children[0] as Element;
+        const cdata = root.children[0];
+        expect(cdata.type).toBe("cdata");
+        expect((cdata as Element).children[0]).toMatchObject({
+            type: "text",
+            data: "a<b",
+        });
+    });
+
     it("createDocumentStream", () => {
         let documentStream!: Parser;
 


### PR DESCRIPTION
### Summary

In default HTML mode, `<![CDATA[` outside foreign content is tokenized with the wrong end-condition. On a full `CDATA[` match, `stateCDATASequence` always enters the comment-like CDATA path (`InCommentLike` with the `]]>` end sequence), so the section only ends at `]]>` (or EOF). Per the WHATWG HTML spec, `<![CDATA[` in this position is a **bogus comment** that ends at the first `>`, leaving everything after `>` as live markup.

Because of this, htmlparser2 collapses a CDATA-prefixed string plus all following markup into a single inert comment node, instead of emitting a short comment followed by the live elements.

### Spec

- [§13.2.5.42 Markup declaration open state](https://html.spec.whatwg.org/multipage/parsing.html#markup-declaration-open-state): `<![CDATA[` is only consumed as a CDATA section when there is an adjusted current node that is not an element in the HTML namespace (foreign content); otherwise it is a parse error and the tokenizer switches to the bogus comment state.
- [§13.2.5.43 Bogus comment state](https://html.spec.whatwg.org/multipage/parsing.html#bogus-comment-state): a bogus comment ends at the first `>`.

### Reproduction

```js
import * as htmlparser2 from "htmlparser2";
const dom = htmlparser2.parseDocument("<![CDATA[x><img src=x onerror=alert(1)>");
```

Current `master`:

```
COMMENT "[CDATA[x><img src=x onerror=alert(1)>"   // single node, <img> never parsed
```

parse5 (used here as a differential spec oracle) and every browser:

```
COMMENT "[CDATA[x"
ELEMENT <img src=x onerror=alert(1)>              // live element
```

The trailing `onerror` attribute is only there to make the divergence visible: in the buggy output the markup after `>` is hidden inside a comment; in the spec output it is a real `img` element. This is a parser-correctness issue, not an exploit report.

### Prior acknowledgement

This is the same behavior reported in #119 ("CDATA parsing is not correct when it is not in xmlMode"). The reporter verified against Gumbo and parse5 that `<![CDATA[ > <div> xxx </div>]]>` should yield a bogus comment `<![CDATA[ >` followed by live `<div>xxx</div>` markup, and the maintainer confirmed: "Ahh, right. I forgot it behaved this way. This will be fixed with #114." #114 (the high5 tokenizer rewrite) never landed, so the bug is still present on `master`.

It also runs counter to the recent spec-alignment work in #2382, #2383, and #2387.

### Fix

`stateCDATASequence` now only takes the real-CDATA path (`InCommentLike` + `]]>`) when CDATA should actually be recognized, via a new `shouldRecognizeCDATA()` helper that checks `xmlMode || recognizeCDATA || isInForeignContext()`. In default HTML mode it routes to `InSpecialComment` (bogus comment ending at `>`), exactly like the existing partial-match branch a few lines below already does. `recognizeCDATA` is read from the options already passed to the tokenizer.

`xmlMode`, foreign-content (SVG/MathML), and `recognizeCDATA` real-CDATA behavior is preserved.

### Tests

Added to `src/index.spec.ts`:

- a red-baseline assertion that `<![CDATA[x><img src=x>` in HTML mode yields a comment ending at `>` plus a live `img` element (mirrors the parse5 tree above; fails on `master`, passes with this change);
- two regression guards confirming real CDATA in foreign content and in `xmlMode` is still recognized.

Full suite green:

```
Test Files  7 passed (7)
     Tests  190 passed (190)
```

No snapshot files changed, so existing CDATA tokenizer cases (`<![CDATA[ foo ]]>`, `<![CD>`, unclosed-at-EOF, `recognizeCDATA` edge cases) keep their current behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optionally recognizing CDATA sections during parsing.
  * Improved handling of `<![CDATA[` so it behaves correctly in XML mode and foreign content.

* **Bug Fixes**
  * In HTML mode, `<![CDATA[` is now treated as a bogus comment outside foreign content, preventing unintended parsing of following markup.
  * Preserved CDATA content more reliably in supported parsing contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->