### PR TITLE
feat(parser): add openImpliesClose option to disable implicit HTML changes

### DIFF
--- a/src/Parser.events.spec.ts
+++ b/src/Parser.events.spec.ts
@@ -301,6 +301,15 @@ describe("Events", () => {
             '<Page\n    title="Hello world"\n    actionBarVisible="false"/>',
             { xmlMode: true },
         ));
+
+    it("openImpliesClose=false: no implicit close via map", () =>
+        runTest("<p>first<p>second</p></p>", { openImpliesClose: false }));
+
+    it("openImpliesClose=false: no implicit p open before close", () =>
+        runTest("<div>text</p></div>", { openImpliesClose: false }));
+
+    it("openImpliesClose=false: no implicit br open before close", () =>
+        runTest("<div>text</br></div>", { openImpliesClose: false }));
 });
 
 describe("Helper", () => {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -292,7 +292,6 @@ export class Parser implements Callbacks {
     private readonly recognizeSelfClosing: boolean;
     /** We are parsing HTML. Inverse of the `xmlMode` option. */
     private readonly htmlMode: boolean;
-    private readonly openImpliesClose: boolean;
     /** Whether implicit open/close logic is active (requires HTML mode + openImpliesClose option). */
     private readonly impliesCloseEnabled: boolean;
     private readonly tokenizer: Tokenizer;
@@ -310,8 +309,7 @@ export class Parser implements Callbacks {
     ) {
         this.cbs = cbs ?? {};
         this.htmlMode = !this.options.xmlMode;
-        this.openImpliesClose = options.openImpliesClose ?? this.htmlMode;
-        this.impliesCloseEnabled = this.htmlMode && this.openImpliesClose;
+        this.impliesCloseEnabled = this.htmlMode && (options.openImpliesClose ?? this.htmlMode);
         this.lowerCaseTagNames = options.lowerCaseTags ?? this.htmlMode;
         this.lowerCaseAttributeNames =
             options.lowerCaseAttributeNames ?? this.htmlMode;

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -208,6 +208,16 @@ export interface ParserOptions {
      * Allows the default tokenizer to be overwritten.
      */
     Tokenizer?: typeof Tokenizer;
+
+    /**
+     * If set to `true`, the parser will implicitly open and close HTML tags
+     * according to the HTML5 spec (e.g. `<p>` will implicitly close another
+     * `<p>` that is still open, `</p>` will implicitly open `<p>` if none is
+     * open). Set to `false` to disable all implicit HTML changes, preserving
+     * the original document structure more closely.
+     * @default !xmlMode
+     */
+    openImpliesClose?: boolean;
 }
 
 /**
@@ -280,6 +290,7 @@ export class Parser implements Callbacks {
     private readonly recognizeSelfClosing: boolean;
     /** We are parsing HTML. Inverse of the `xmlMode` option. */
     private readonly htmlMode: boolean;
+    private readonly openImpliesClose: boolean;
     private readonly tokenizer: Tokenizer;
 
     private readonly buffers: string[] = [];
@@ -295,6 +306,7 @@ export class Parser implements Callbacks {
     ) {
         this.cbs = cbs ?? {};
         this.htmlMode = !this.options.xmlMode;
+        this.openImpliesClose = options.openImpliesClose ?? this.htmlMode;
         this.lowerCaseTagNames = options.lowerCaseTags ?? this.htmlMode;
         this.lowerCaseAttributeNames =
             options.lowerCaseAttributeNames ?? this.htmlMode;
@@ -410,12 +422,12 @@ export class Parser implements Callbacks {
          * stays null so endOpenTag is a no-op, and closeCurrentTag can't
          * match "" on the stack.
          */
-        if (this.htmlMode && name === "form" && this.stack.includes("form")) {
+        if (this.htmlMode && this.openImpliesClose && name === "form" && this.stack.includes("form")) {
             this.tagname = "";
             return;
         }
 
-        const impliesClose = this.htmlMode && openImpliesClose.get(name);
+        const impliesClose = this.htmlMode && this.openImpliesClose && openImpliesClose.get(name);
 
         if (impliesClose) {
             while (this.stack.length > 0 && impliesClose.has(this.stack[0])) {
@@ -481,12 +493,12 @@ export class Parser implements Callbacks {
                     this.popElement(true);
                 }
                 this.popElement(false);
-            } else if (this.htmlMode && name === "p") {
+            } else if (this.htmlMode && this.openImpliesClose && name === "p") {
                 // Implicit open before close
                 this.emitOpenTag("p");
                 this.closeCurrentTag(true);
             }
-        } else if (this.htmlMode && name === "br") {
+        } else if (this.htmlMode && this.openImpliesClose && name === "br") {
             // We can't use `emitOpenTag` for implicit open, as `br` would be implicitly closed.
             this.cbs.onopentagname?.("br");
             this.cbs.onopentag?.("br", {}, true);

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -17,7 +17,7 @@ const tableSectionTags = new Set(["thead", "tbody", "tfoot", "tr", "td", "th"]);
 const ddtTags = new Set(["dd", "dt"]);
 const rtpTags = new Set(["rt", "rp"]);
 
-const openImpliesClose = new Map<string, Set<string>>([
+const impliesCloseMap = new Map<string, Set<string>>([
     ["tr", new Set(["tr", "th", "td"])],
     ["th", new Set(["th", "td"])],
     ["td", new Set(["thead", "th", "td"])],
@@ -427,7 +427,7 @@ export class Parser implements Callbacks {
             return;
         }
 
-        const impliesClose = this.htmlMode && this.openImpliesClose && openImpliesClose.get(name);
+        const impliesClose = this.htmlMode && this.openImpliesClose && impliesCloseMap.get(name);
 
         if (impliesClose) {
             while (this.stack.length > 0 && impliesClose.has(this.stack[0])) {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -215,6 +215,8 @@ export interface ParserOptions {
      * `<p>` that is still open, `</p>` will implicitly open `<p>` if none is
      * open). Set to `false` to disable all implicit HTML changes, preserving
      * the original document structure more closely.
+     *
+     * This option has no effect when `xmlMode` is `true`.
      * @default !xmlMode
      */
     openImpliesClose?: boolean;
@@ -291,6 +293,8 @@ export class Parser implements Callbacks {
     /** We are parsing HTML. Inverse of the `xmlMode` option. */
     private readonly htmlMode: boolean;
     private readonly openImpliesClose: boolean;
+    /** Whether implicit open/close logic is active (requires HTML mode + openImpliesClose option). */
+    private readonly impliesCloseEnabled: boolean;
     private readonly tokenizer: Tokenizer;
 
     private readonly buffers: string[] = [];
@@ -307,6 +311,7 @@ export class Parser implements Callbacks {
         this.cbs = cbs ?? {};
         this.htmlMode = !this.options.xmlMode;
         this.openImpliesClose = options.openImpliesClose ?? this.htmlMode;
+        this.impliesCloseEnabled = this.htmlMode && this.openImpliesClose;
         this.lowerCaseTagNames = options.lowerCaseTags ?? this.htmlMode;
         this.lowerCaseAttributeNames =
             options.lowerCaseAttributeNames ?? this.htmlMode;
@@ -422,12 +427,12 @@ export class Parser implements Callbacks {
          * stays null so endOpenTag is a no-op, and closeCurrentTag can't
          * match "" on the stack.
          */
-        if (this.htmlMode && this.openImpliesClose && name === "form" && this.stack.includes("form")) {
+        if (this.impliesCloseEnabled && name === "form" && this.stack.includes("form")) {
             this.tagname = "";
             return;
         }
 
-        const impliesClose = this.htmlMode && this.openImpliesClose && impliesCloseMap.get(name);
+        const impliesClose = this.impliesCloseEnabled && impliesCloseMap.get(name);
 
         if (impliesClose) {
             while (this.stack.length > 0 && impliesClose.has(this.stack[0])) {
@@ -493,12 +498,12 @@ export class Parser implements Callbacks {
                     this.popElement(true);
                 }
                 this.popElement(false);
-            } else if (this.htmlMode && this.openImpliesClose && name === "p") {
+            } else if (this.impliesCloseEnabled && name === "p") {
                 // Implicit open before close
                 this.emitOpenTag("p");
                 this.closeCurrentTag(true);
             }
-        } else if (this.htmlMode && this.openImpliesClose && name === "br") {
+        } else if (this.impliesCloseEnabled && name === "br") {
             // We can't use `emitOpenTag` for implicit open, as `br` would be implicitly closed.
             this.cbs.onopentagname?.("br");
             this.cbs.onopentag?.("br", {}, true);

--- a/src/__snapshots__/Parser.events.spec.ts.snap
+++ b/src/__snapshots__/Parser.events.spec.ts.snap
@@ -5304,6 +5304,161 @@ exports[`Events > open-implies-close case of (non-br) void close tag in non-XML 
 ]
 `;
 
+exports[`Events > openImpliesClose=false: no implicit br open before close 1`] = `
+[
+  {
+    "$event": "opentagname",
+    "data": [
+      "div",
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "div",
+      {},
+      false,
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "text",
+    ],
+    "endIndex": 8,
+    "startIndex": 5,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "div",
+      false,
+    ],
+    "endIndex": 19,
+    "startIndex": 14,
+  },
+]
+`;
+
+exports[`Events > openImpliesClose=false: no implicit close via map 1`] = `
+[
+  {
+    "$event": "opentagname",
+    "data": [
+      "p",
+    ],
+    "endIndex": 2,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "p",
+      {},
+      false,
+    ],
+    "endIndex": 2,
+    "startIndex": 0,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "first",
+    ],
+    "endIndex": 7,
+    "startIndex": 3,
+  },
+  {
+    "$event": "opentagname",
+    "data": [
+      "p",
+    ],
+    "endIndex": 10,
+    "startIndex": 8,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "p",
+      {},
+      false,
+    ],
+    "endIndex": 10,
+    "startIndex": 8,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "second",
+    ],
+    "endIndex": 16,
+    "startIndex": 11,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "p",
+      false,
+    ],
+    "endIndex": 20,
+    "startIndex": 17,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "p",
+      false,
+    ],
+    "endIndex": 24,
+    "startIndex": 21,
+  },
+]
+`;
+
+exports[`Events > openImpliesClose=false: no implicit p open before close 1`] = `
+[
+  {
+    "$event": "opentagname",
+    "data": [
+      "div",
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "div",
+      {},
+      false,
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "text",
+    ],
+    "endIndex": 8,
+    "startIndex": 5,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "div",
+      false,
+    ],
+    "endIndex": 18,
+    "startIndex": 13,
+  },
+]
+`;
+
 exports[`Events > plaintext 1`] = `
 [
   {


### PR DESCRIPTION
## Summary

Adds a new `openImpliesClose` option to `ParserOptions` that controls whether the parser performs implicit HTML tag open/close operations per the HTML5 spec. When set to `false`, the parser preserves the original document structure without adding or removing tags that weren't explicitly in the source.

This is useful for users who want to parse and serialize HTML without having the parser alter invalid or non-standard markup.

## Changes

- Added `openImpliesClose` option to `ParserOptions` (default: `!xmlMode`, i.e. `true` in HTML mode)
- Guarded all implicit behavior behind this option:
  - Implicit close via the `openImpliesClose` map (e.g. `<p>` closing another open `<p>`)
  - Second `<form>` suppression
  - Implicit `<p>` open before `</p>` close
  - Implicit `<br>` open before `</br>` close
- All existing tests continue to pass (backward compatible)

## Related

Closes #2428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new parser option to control HTML5-style implicit open/close behavior (`openImpliesClose`).
  * When enabled/disabled, implicit tag opening/closing behavior is applied accordingly in HTML mode (including nested paragraphs and line-break related cases).
* **Tests**
  * Added new event test coverage for `openImpliesClose: false` to confirm implicit close/open sequences are suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->