### PR TITLE
chore: pin github actions and harden workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,12 +20,14 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v7
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v4
+              uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
               with:
                   languages: "javascript"
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v4
+              uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,6 +1,6 @@
 # Based on https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
 name: Dependabot auto-merge
-on: pull_request_target
+on: pull_request
 
 permissions:
     pull-requests: write
@@ -9,11 +9,11 @@ permissions:
 jobs:
     dependabot:
         runs-on: ubuntu-latest
-        if: ${{ github.actor == 'dependabot[bot]' }}
+        if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'fb55/htmlparser2'
         steps:
             - name: Dependabot metadata
               id: metadata
-              uses: dependabot/fetch-metadata@v3.1.0
+              uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
               with:
                   github-token: "${{ secrets.GITHUB_TOKEN }}"
             - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -17,8 +17,10 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: lts/*
                   cache: npm
@@ -39,9 +41,11 @@ jobs:
                     - "lts/*"
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
             - name: Use Node.js ${{ matrix.node }}
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: ${{ matrix.node }}
                   cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,11 @@ jobs:
             id-token: write
 
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: lts/*
                   registry-url: https://registry.npmjs.org


### PR DESCRIPTION
- Pin all actions to a sha (dependabot supports this and will update
  them)
- Disable credentials caching when checking out branches
- Change the automerge workflow to use `pull_request` (the linked doc in
  the workflow does this)
- Change the automerge workflow to check the user login rather than the
  HEAD actor name


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use fixed, versioned action references for more consistent builds and maintenance.
  * Improved Dependabot automation checks and workflow triggers for safer, more predictable pull request handling.
  * Kept CI and release-related workflows aligned across test, analysis, and publish steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->