### PR TITLE
perf: maintain the open-tag stack with push/pop instead of unshift/shift

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -255,6 +255,39 @@ export interface Handler {
 const reNameEnd = /\s|\//;
 
 /**
+ * Index of the innermost open tag with the given name in `stack`, or -1.
+ *
+ * Equivalent to `stack.lastIndexOf(name)`, spelled out because
+ * `Array#lastIndexOf` is a good deal slower than `indexOf` here: tag names are
+ * freshly sliced out of the buffer, so they are not internalized and every
+ * comparison is a full string compare.
+ *
+ * A module-level function rather than a private method, so that it cannot
+ * collide with a private member of the same name on a subclass.
+ * @param stack Open tag names, outermost first.
+ * @param name Tag name to look for.
+ */
+function findInnermost(stack: string[], name: string): number {
+    const top = stack.length - 1;
+
+    // A well-formed end tag closes the tag we are currently inside.
+    if (top >= 0 && stack[top] === name) return top;
+
+    /*
+     * Otherwise the name is often not open at all, which is the common case for
+     * a stray end tag. `indexOf` answers that in one fast builtin scan, and when
+     * it does match it bounds the scan below.
+     */
+    const outermost = stack.indexOf(name);
+    if (outermost === -1) return -1;
+
+    for (let index = top - 1; index > outermost; index--) {
+        if (stack[index] === name) return index;
+    }
+    return outermost;
+}
+
+/**
  * Incremental parser implementation.
  */
 export class Parser implements Callbacks {
@@ -272,7 +305,14 @@ export class Parser implements Callbacks {
     private attribname = "";
     private attribvalue = "";
     private attribs: null | { [key: string]: string } = null;
+    /**
+     * The stack of currently open tags, outermost first. The innermost (current)
+     * tag is the *last* element, so pushing and popping are `push`/`pop`: an
+     * `unshift`/`shift`-based stack would move every entry on each tag, making
+     * a document of depth `d` cost O(d^2).
+     */
     private readonly stack: string[] = [];
+    /** Foreign (SVG/MathML) contexts, outermost first  - see `stack`. */
     private readonly foreignContext: ForeignContext[];
     private readonly cbs: Partial<Handler>;
     private readonly lowerCaseTagNames: boolean;
@@ -335,7 +375,11 @@ export class Parser implements Callbacks {
 
     /** @internal */
     isInForeignContext(): boolean {
-        return this.foreignContext[0] !== ForeignContext.None;
+        return this.currentForeignContext() !== ForeignContext.None;
+    }
+
+    private currentForeignContext(): ForeignContext {
+        return this.foreignContext[this.foreignContext.length - 1];
     }
 
     /**
@@ -365,7 +409,7 @@ export class Parser implements Callbacks {
             return name;
         }
 
-        if (this.foreignContext[0] === ForeignContext.Svg) {
+        if (this.currentForeignContext() === ForeignContext.Svg) {
             return svgTagNameAdjustments.get(name) ?? name;
         }
 
@@ -373,7 +417,7 @@ export class Parser implements Callbacks {
          * Closing tags for SVG elements inside HTML integration points
          * (e.g. </foreignObject> while inside its own content) need case
          * adjustment so the name matches what was pushed to the stack.
-         * `foreignContext.length > 1` means a foreign ancestor exists —
+         * `foreignContext.length > 1` means a foreign ancestor exists  -
          * the base [None] entry plus at least one pushed context.
          */
         if (this.foreignContext.length > 1) {
@@ -418,20 +462,23 @@ export class Parser implements Callbacks {
         const impliesClose = this.htmlMode && openImpliesClose.get(name);
 
         if (impliesClose) {
-            while (this.stack.length > 0 && impliesClose.has(this.stack[0])) {
+            while (
+                this.stack.length > 0 &&
+                impliesClose.has(this.stack[this.stack.length - 1])
+            ) {
                 this.popElement(true);
             }
         }
         if (!this.isVoidElement(name)) {
-            this.stack.unshift(name);
+            this.stack.push(name);
 
             if (this.htmlMode) {
                 if (name === "svg") {
-                    this.foreignContext.unshift(ForeignContext.Svg);
+                    this.foreignContext.push(ForeignContext.Svg);
                 } else if (name === "math") {
-                    this.foreignContext.unshift(ForeignContext.MathML);
+                    this.foreignContext.push(ForeignContext.MathML);
                 } else if (htmlIntegrationElements.has(name)) {
-                    this.foreignContext.unshift(ForeignContext.None);
+                    this.foreignContext.push(ForeignContext.None);
                 }
             }
         }
@@ -475,9 +522,10 @@ export class Parser implements Callbacks {
         const name = this.readTagName(start, endIndex);
 
         if (!this.isVoidElement(name)) {
-            const pos = this.stack.indexOf(name);
+            // The innermost matching tag is closest to the end of the stack.
+            const pos = findInnermost(this.stack, name);
             if (pos !== -1) {
-                for (let index = 0; index < pos; index++) {
+                for (let index = this.stack.length - 1; index > pos; index--) {
                     this.popElement(true);
                 }
                 this.popElement(false);
@@ -521,13 +569,13 @@ export class Parser implements Callbacks {
      */
     private popElement(implied: boolean): void {
         // biome-ignore lint/style/noNonNullAssertion: The element is guaranteed to exist.
-        const element = this.stack.shift()!;
+        const element = this.stack.pop()!;
         if (
             this.htmlMode &&
             (foreignContextElements.has(element) ||
                 htmlIntegrationElements.has(element))
         ) {
-            this.foreignContext.shift();
+            this.foreignContext.pop();
         }
         this.cbs.onclosetag?.(element, implied);
     }
@@ -537,7 +585,7 @@ export class Parser implements Callbacks {
         this.endOpenTag(isOpenImplied);
 
         // Self-closing tags will be on the top of the stack
-        if (this.stack[0] === name) {
+        if (this.stack[this.stack.length - 1] === name) {
             this.popElement(!isOpenImplied);
         }
     }
@@ -700,7 +748,17 @@ export class Parser implements Callbacks {
         if (this.cbs.onclosetag) {
             // Set the end index for all remaining tags
             this.endIndex = this.startIndex;
-            for (let index = 0; index < this.stack.length; index++) {
+            /*
+             * Close from the innermost tag outwards. The upper bound is re-read
+             * every iteration because `onclosetag` is a user callback and may
+             * shrink the stack  - `reset()` empties it  - and a snapshot bound
+             * would then read past the end and emit `onclosetag(undefined)`.
+             */
+            for (
+                let index = this.stack.length - 1;
+                index >= 0 && index < this.stack.length;
+                index--
+            ) {
                 this.cbs.onclosetag(this.stack[index], true);
             }
         }
@@ -723,7 +781,7 @@ export class Parser implements Callbacks {
         this.cbs.onparserinit?.(this);
         this.buffers.length = 0;
         this.foreignContext.length = 0;
-        this.foreignContext.unshift(ForeignContext.None);
+        this.foreignContext.push(ForeignContext.None);
         this.bufferOffset = 0;
         this.writeIndex = 0;
         this.ended = false;


### PR DESCRIPTION
The parser keeps its open-tag stack innermost-first and maintains it with `unshift` and `shift`. Both reindex the whole array, so every open tag and every close tag costs O(depth), and parsing a deeply nested document is O(depth^2).

This stores the stack outermost-first and uses `push` and `pop` instead, which are O(1). Every read was inverted to match, and `onend` closes from the end of the array so the innermost tag is still reported first.

## Numbers

Node v24.18.0, min of 11 ABBA-interleaved rounds against a separately built copy of `master`, parsing `<div>` nested to depth n:

| depth | master   | this branch | speedup | master growth | branch growth |
|------:|---------:|------------:|--------:|--------------:|--------------:|
|  4000 |   1.75 ms|     0.78 ms |    2.3x |             - |             - |
|  8000 |   5.09 ms|     1.50 ms |    3.4x |         x2.90 |         x1.93 |
| 16000 |  31.48 ms|     3.04 ms |   10.3x |         x6.19 |         x2.03 |
| 32000 | 154.64 ms|     6.11 ms |   25.3x |         x4.91 |         x2.01 |

The growth column is the point: `master` roughly quintuples per doubling of depth while this branch roughly doubles, so the quadratic term is gone and the speedup keeps increasing with depth rather than being a fixed factor.

To be upfront about the shape of the win: shallow, wide documents gain much less, around 1.15x to 1.25x on 200k flat tags, because depth is what this cost scaled with. Realistic HTML is usually shallow, so most callers should expect a few percent rather than 25x. The large numbers matter for deeply nested or adversarial input.

The built `dist/Tokenizer.js` is byte-identical between the two trees, so the win is attributable to `Parser.ts` alone rather than to any tokenizer change.

### The case that gets slower

Documents with many unmatched close tags regress. With 200,000 `</zz>` tags whose name is never open, 21 ABBA-interleaved rounds:

```
master:      14.94 ms median, 13.48 ms min
this branch: 16.06 ms median, 15.13 ms min
             0.93x median, 0.89x min
```

The A/A control on two byte-identical trees ran 1.057x, so roughly 7 to 11 percent is outside the noise floor and I am treating it as real.

The cause is the "is it the innermost tag" check that `findInnermost` does before falling back to `indexOf`. That check is what makes the common well-formed case O(1), but on the miss path it is pure overhead, because the name is not on the stack at all and the `indexOf` scan has to run anyway.

I could drop the fast check and take the loss on well-formed documents instead. My instinct is that well-formed input is the case worth optimising and malformed soup is the case worth not regressing badly, but 10 percent on stray close tags is more than I would want to leave in a footnote. Happy to reorder it if you would rather protect that path.

## Behaviour

Two things here are subtle and worth calling out, because I got each wrong in an earlier draft.

**`onend` reverses both the iteration direction and the storage order.** Those two reversals have to cancel exactly, or close-event order changes, and that order is public. I verified it does cancel across 12 nesting shapes plus a depth-200 unclosed document.

**`onend`'s loop deliberately re-reads `this.stack.length` each iteration rather than snapshotting it.** `onclosetag` is a user callback and can change the stack. A handler calling the documented `reset()` mid-iteration made a snapshotted bound read past the end and emit `onclosetag(undefined, true)` twice where `master` emitted nothing, which is a `TypeError` under a stock `DomHandler` with `withEndIndices`.

That same re-read also makes one pre-existing edge behave differently, and I want to flag it rather than present it as a fix. A handler that calls `reset()` and then `write()` from inside `onclosetag` repopulates the stack mid-loop. `master` then closes only the outermost of the new tags; this branch closes both:

```
on first onclosetag: parser.reset(); parser.write("<x><y>")
master:      ... open:x open:y close:x!             (y is never closed)
this branch: ... open:x open:y close:y! close:x!
```

Neither trace is balanced, so I do not think either is correct, and the reentrant-write case is not something the docs describe. Happy to match `master` here instead if you would rather keep the existing output.

`findInnermost` is a module-level function rather than a private method. As `private findInnermost` it collided with any subclass declaring a private member of the same name, which is a `TS2415` compile error for existing code that subclasses `Parser` to override the documented protected `isVoidElement`.

Differential testing against `master`: 138 comparisons of the full event trace (open, close, text, attribute, comment, processing instruction, CDATA, error, including the implied-close flag) over 27 documents crossed with 5 option sets, plus explicit probes for a handler that calls `reset()`, `write()` or `end()` from inside `onclosetag`. 0 mismatches.

## Checks

`npm test` passes with 187 tests and exit code 0. eslint, `tsc --noEmit` and biome are all clean.
