### PR TITLE
fix: acknowledge self-closing flag on foreign integration points

### DIFF
--- a/src/Parser.events.spec.ts
+++ b/src/Parser.events.spec.ts
@@ -215,6 +215,15 @@ describe("Events", () => {
             recognizeSelfClosing: true,
         }));
 
+    it("Self-closing SVG integration point acknowledges the slash", () =>
+        runTest("<svg><foreignObject/>x</svg>"));
+
+    it("Self-closing SVG title acknowledges the slash", () =>
+        runTest("<svg><title/>x</svg>"));
+
+    it("Self-closing MathML integration point acknowledges the slash", () =>
+        runTest("<math><mi/>x</math>"));
+
     it("HTML image alias", () => runTest("<image></image>"));
 
     it("SVG image is not aliased", () => runTest("<svg><image></image></svg>"));

--- a/src/Parser.events.spec.ts
+++ b/src/Parser.events.spec.ts
@@ -221,8 +221,21 @@ describe("Events", () => {
     it("Self-closing SVG title acknowledges the slash", () =>
         runTest("<svg><title/>x</svg>"));
 
+    it("Self-closing SVG desc acknowledges the slash", () =>
+        runTest("<svg><desc/>x</svg>"));
+
     it("Self-closing MathML integration point acknowledges the slash", () =>
         runTest("<math><mi/>x</math>"));
+
+    it("Self-closing MathML annotation-xml acknowledges the slash", () =>
+        runTest("<math><annotation-xml/>x</math>"));
+
+    it("Self-closing HTML descendant of an integration point ignores the slash", () =>
+        /*
+         * `title` here is HTML (inside foreignObject's HTML context), not a
+         * foreign integration point, so its slash must not be acknowledged.
+         */
+        runTest("<svg><foreignObject><title/>x</foreignObject></svg>"));
 
     it("HTML image alias", () => runTest("<image></image>"));
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -339,6 +339,25 @@ export class Parser implements Callbacks {
     }
 
     /**
+     * Whether the element currently being opened is a foreign (SVG/MathML)
+     * element. Foreign elements acknowledge the self-closing flag even in HTML
+     * mode.
+     *
+     * HTML integration points (e.g. `<foreignObject>`, or `<title>` inside
+     * `<svg>`) switch their *children* back to the HTML context, so
+     * `isInForeignContext()` reports `false` for them even though the element
+     * itself is foreign. For those, check the enclosing context instead.
+     */
+    private currentTagIsForeign(): boolean {
+        return (
+            this.isInForeignContext() ||
+            (this.htmlMode &&
+                htmlIntegrationElements.has(this.tagname) &&
+                this.foreignContext[1] !== ForeignContext.None)
+        );
+    }
+
+    /**
      * Checks if the current tag is a void element. Override this if you want
      * to specify your own additional void elements.
      * @param name Name of the pseudo selector.
@@ -503,7 +522,7 @@ export class Parser implements Callbacks {
      */
     onselfclosingtag(endIndex: number): void {
         this.endIndex = endIndex;
-        if (this.recognizeSelfClosing || this.isInForeignContext()) {
+        if (this.recognizeSelfClosing || this.currentTagIsForeign()) {
             this.closeCurrentTag(false);
 
             // Set `startIndex` for next node

--- a/src/__snapshots__/Parser.events.spec.ts.snap
+++ b/src/__snapshots__/Parser.events.spec.ts.snap
@@ -2767,6 +2767,167 @@ exports[`Events > Scripts ending with < 1`] = `
 ]
 `;
 
+exports[`Events > Self-closing HTML descendant of an integration point ignores the slash 1`] = `
+[
+  {
+    "$event": "opentagname",
+    "data": [
+      "svg",
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "svg",
+      {},
+      false,
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentagname",
+    "data": [
+      "foreignObject",
+    ],
+    "endIndex": 19,
+    "startIndex": 5,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "foreignObject",
+      {},
+      false,
+    ],
+    "endIndex": 19,
+    "startIndex": 5,
+  },
+  {
+    "$event": "opentagname",
+    "data": [
+      "title",
+    ],
+    "endIndex": 26,
+    "startIndex": 20,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "title",
+      {},
+      false,
+    ],
+    "endIndex": 27,
+    "startIndex": 20,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "x</foreignObject></svg>",
+    ],
+    "endIndex": 50,
+    "startIndex": 28,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "title",
+      true,
+    ],
+    "endIndex": 51,
+    "startIndex": 51,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "foreignObject",
+      true,
+    ],
+    "endIndex": 51,
+    "startIndex": 51,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "svg",
+      true,
+    ],
+    "endIndex": 51,
+    "startIndex": 51,
+  },
+]
+`;
+
+exports[`Events > Self-closing MathML annotation-xml acknowledges the slash 1`] = `
+[
+  {
+    "$event": "opentagname",
+    "data": [
+      "math",
+    ],
+    "endIndex": 5,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "math",
+      {},
+      false,
+    ],
+    "endIndex": 5,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentagname",
+    "data": [
+      "annotation-xml",
+    ],
+    "endIndex": 21,
+    "startIndex": 6,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "annotation-xml",
+      {},
+      false,
+    ],
+    "endIndex": 22,
+    "startIndex": 6,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "annotation-xml",
+      true,
+    ],
+    "endIndex": 22,
+    "startIndex": 6,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "x",
+    ],
+    "endIndex": 23,
+    "startIndex": 23,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "math",
+      false,
+    ],
+    "endIndex": 30,
+    "startIndex": 24,
+  },
+]
+`;
+
 exports[`Events > Self-closing MathML integration point acknowledges the slash 1`] = `
 [
   {
@@ -2830,6 +2991,73 @@ exports[`Events > Self-closing MathML integration point acknowledges the slash 1
     ],
     "endIndex": 18,
     "startIndex": 12,
+  },
+]
+`;
+
+exports[`Events > Self-closing SVG desc acknowledges the slash 1`] = `
+[
+  {
+    "$event": "opentagname",
+    "data": [
+      "svg",
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "svg",
+      {},
+      false,
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentagname",
+    "data": [
+      "desc",
+    ],
+    "endIndex": 10,
+    "startIndex": 5,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "desc",
+      {},
+      false,
+    ],
+    "endIndex": 11,
+    "startIndex": 5,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "desc",
+      true,
+    ],
+    "endIndex": 11,
+    "startIndex": 5,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "x",
+    ],
+    "endIndex": 12,
+    "startIndex": 12,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "svg",
+      false,
+    ],
+    "endIndex": 18,
+    "startIndex": 13,
   },
 ]
 `;

--- a/src/__snapshots__/Parser.events.spec.ts.snap
+++ b/src/__snapshots__/Parser.events.spec.ts.snap
@@ -2767,6 +2767,207 @@ exports[`Events > Scripts ending with < 1`] = `
 ]
 `;
 
+exports[`Events > Self-closing MathML integration point acknowledges the slash 1`] = `
+[
+  {
+    "$event": "opentagname",
+    "data": [
+      "math",
+    ],
+    "endIndex": 5,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "math",
+      {},
+      false,
+    ],
+    "endIndex": 5,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentagname",
+    "data": [
+      "mi",
+    ],
+    "endIndex": 9,
+    "startIndex": 6,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "mi",
+      {},
+      false,
+    ],
+    "endIndex": 10,
+    "startIndex": 6,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "mi",
+      true,
+    ],
+    "endIndex": 10,
+    "startIndex": 6,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "x",
+    ],
+    "endIndex": 11,
+    "startIndex": 11,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "math",
+      false,
+    ],
+    "endIndex": 18,
+    "startIndex": 12,
+  },
+]
+`;
+
+exports[`Events > Self-closing SVG integration point acknowledges the slash 1`] = `
+[
+  {
+    "$event": "opentagname",
+    "data": [
+      "svg",
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "svg",
+      {},
+      false,
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentagname",
+    "data": [
+      "foreignObject",
+    ],
+    "endIndex": 19,
+    "startIndex": 5,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "foreignObject",
+      {},
+      false,
+    ],
+    "endIndex": 20,
+    "startIndex": 5,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "foreignObject",
+      true,
+    ],
+    "endIndex": 20,
+    "startIndex": 5,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "x",
+    ],
+    "endIndex": 21,
+    "startIndex": 21,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "svg",
+      false,
+    ],
+    "endIndex": 27,
+    "startIndex": 22,
+  },
+]
+`;
+
+exports[`Events > Self-closing SVG title acknowledges the slash 1`] = `
+[
+  {
+    "$event": "opentagname",
+    "data": [
+      "svg",
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "svg",
+      {},
+      false,
+    ],
+    "endIndex": 4,
+    "startIndex": 0,
+  },
+  {
+    "$event": "opentagname",
+    "data": [
+      "title",
+    ],
+    "endIndex": 11,
+    "startIndex": 5,
+  },
+  {
+    "$event": "opentag",
+    "data": [
+      "title",
+      {},
+      false,
+    ],
+    "endIndex": 12,
+    "startIndex": 5,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "title",
+      true,
+    ],
+    "endIndex": 12,
+    "startIndex": 5,
+  },
+  {
+    "$event": "text",
+    "data": [
+      "x",
+    ],
+    "endIndex": 13,
+    "startIndex": 13,
+  },
+  {
+    "$event": "closetag",
+    "data": [
+      "svg",
+      false,
+    ],
+    "endIndex": 19,
+    "startIndex": 14,
+  },
+]
+`;
+
 exports[`Events > Self-closing foreign element with recognizeSelfClosing 1`] = `
 [
   {


### PR DESCRIPTION
## Problem

In HTML mode the self-closing flag is honored for foreign (SVG/MathML) elements — `<svg><rect/>x</svg>` closes `rect` and keeps `x` as a sibling. But HTML integration points (`<foreignObject>`, `<title>`/`<desc>` inside `<svg>`, `<mi>`/`<annotation-xml>` inside `<math>`) are themselves foreign elements while parsing their *children* as HTML. Opening one pushes an HTML child context, so `isInForeignContext()` returns `false` and `onselfclosingtag` ignores the slash, nesting the following content inside the element:

```js
parseDocument("<svg><foreignObject/>x</svg>")
// before: <foreignObject> contains "x"      (wrong)
// after:  <foreignObject/> empty, "x" sibling (matches parse5)
```

Same for `<svg><title/>`, `<svg><desc/>`, `<math><mi/>`, `<math><annotation-xml/>`, etc.

## Cause

`onselfclosingtag` decided acknowledgement from the *child* context the element establishes instead of from whether the element itself is foreign.

## Fix

Add `currentTagIsForeign()`, which also treats an integration point whose *enclosing* context is foreign as foreign. `<svg><rect/>x</svg>`, `<svg/>x`, and plain-HTML `<title/>` are unchanged.

Tests + snapshots added; `npm test` (190 tests) and lint pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fb55/htmlparser2/pull/2492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of self-closing SVG and MathML elements.
  * Ensured self-closing behavior is handled correctly across foreign-content boundaries.
  * Corrected interpretation of content following SVG integration points, titles, descriptions, MathML integration points, and HTML content inside `foreignObject`.
  * Expanded coverage for these scenarios to help prevent parsing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->